### PR TITLE
Check-style prereq fixes

### DIFF
--- a/nexus-app/src/test/java/com/github/nexus/enclave/keys/KeyManagerTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/enclave/keys/KeyManagerTest.java
@@ -55,7 +55,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void public_key_found_given_private_key() {
+    public void publicKeyFoundGivenPrivateKey() {
 
         final Key publicKey = keyManager.getPublicKeyForPrivateKey(keyPair.getPrivateKey());
 
@@ -63,7 +63,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void exception_thrown_when_private_key_not_found() {
+    public void exceptionThrownWhenPrivateKeyNotFound() {
 
         final Key unknownKey = new Key("unknownKey".getBytes(UTF_8));
         final Throwable throwable = catchThrowable(() -> keyManager.getPublicKeyForPrivateKey(unknownKey));
@@ -73,7 +73,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void private_key_found_given_public_key() {
+    public void privateKeyFoundGivenPublicKey() {
 
         final Key privateKey = keyManager.getPrivateKeyForPublicKey(keyPair.getPublicKey());
 
@@ -81,7 +81,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void exception_thrown_when_public_key_not_found() {
+    public void exceptionThrownWhenPublicKeyNotFound() {
 
         final Key unknownKey = new Key("unknownKey".getBytes(UTF_8));
         final Throwable throwable = catchThrowable(() -> keyManager.getPrivateKeyForPublicKey(unknownKey));
@@ -91,7 +91,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void generating_new_keys_creates_two_files() throws IOException {
+    public void generatingNewKeysCreatesTwoFiles() throws IOException {
 
         final String keyName = "testkey";
 
@@ -113,7 +113,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void generating_new_keys_throws_exception_if_cant_write() throws IOException {
+    public void generatingNewKeysThrowsExceptionIfCantWrite() throws IOException {
 
         final String keyName = "testkey";
 
@@ -129,7 +129,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void load_nonexistant_keys_throws_exception() {
+    public void loadNonexistantKeysThrowsException() {
 
         final Path publicKeyPath = keygenPath.resolve("unknownKey.pub");
         final Path privateKeyPath = keygenPath.resolve("unknownKey.key");
@@ -142,7 +142,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void load_keys_returns_keypair() {
+    public void loadKeysReturnsKeypair() {
         final String keyName = "testkey";
         doReturn(keyPair).when(naclFacade).generateNewKeys();
         final KeyPair generated = keyManager.generateNewKeys(keyName);
@@ -156,7 +156,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void loaded_keys_can_be_searched_for() {
+    public void loadedKeysCanBeSearchedFor() {
         final String keyName = "testkey";
         doReturn(keyPair).when(naclFacade).generateNewKeys();
         final KeyPair generated = keyManager.generateNewKeys(keyName);
@@ -172,7 +172,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void keymanager_loads_given_keys_when_instantiated_with_paths() {
+    public void keymanagerLoadsGivenKeysWhenInstantiatedWithPaths() {
         final String keyName = "testkey";
         doReturn(keyPair).when(naclFacade).generateNewKeys();
         final KeyPair generated = keyManager.generateNewKeys(keyName);
@@ -191,7 +191,7 @@ public class KeyManagerTest {
     }
 
     @Test
-    public void different_number_of_keys_throws_exception() {
+    public void differentNumberOfKeysThrowsException() {
 
         final Throwable throwable = catchThrowable(
                 () -> new KeyManagerImpl(keygenPath.toString(), naclFacade, emptyList(), singletonList(Paths.get(".")))

--- a/nexus-app/src/test/java/com/github/nexus/enclave/keys/model/KeyPairTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/enclave/keys/model/KeyPairTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class KeyPairTest {
 
     @Test
-    public void different_classes_are_not_equal() {
+    public void differentClassesAreNotEqual() {
         final KeyPair keyPair = new KeyPair(
                 new Key("test".getBytes()),
                 new Key("test".getBytes())

--- a/nexus-app/src/test/java/com/github/nexus/enclave/keys/model/KeyTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/enclave/keys/model/KeyTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class KeyTest {
 
     @Test
-    public void different_classes_are_not_equal() {
+    public void differentClassesAreNotEqual() {
         final boolean isEqual = Objects.equals(new Key("test".getBytes()), "test");
 
         assertThat(isEqual).isFalse();

--- a/nexus-app/src/test/java/com/github/nexus/enclave/model/MessageHashTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/enclave/model/MessageHashTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MessageHashTest {
 
     @Test
-    public void message_hash_makes_copy_of_input() {
+    public void messageHashMakesCopyOfInput() {
 
         final byte[] testMessage = "test_message".getBytes();
 
@@ -21,7 +21,7 @@ public class MessageHashTest {
     }
 
     @Test
-    public void test_different_instances_of_same_bytes_is_equal() {
+    public void differentInstancesOfSameBytesIsEqual() {
 
         final byte[] testMessage = "test_message".getBytes();
 
@@ -33,7 +33,7 @@ public class MessageHashTest {
     }
 
     @Test
-    public void test_different_object_types() {
+    public void differentObjectTypesAreNotEqual() {
 
         final byte[] testMessage = "test_message".getBytes();
 
@@ -45,7 +45,7 @@ public class MessageHashTest {
 
     @Test
     public void sameObjectIsEqual() {
-        MessageHash hash = new MessageHash("I LOVE SPARROWS".getBytes());
+        final MessageHash hash = new MessageHash("I LOVE SPARROWS".getBytes());
         assertThat(hash).isEqualTo(hash).hasSameHashCodeAs(hash);
     }
     

--- a/nexus-app/src/test/java/com/github/nexus/encryption/KaliumIT.java
+++ b/nexus-app/src/test/java/com/github/nexus/encryption/KaliumIT.java
@@ -28,7 +28,7 @@ public class KaliumIT {
     }
 
     @Test
-    public void shared_key_pubAprivB_equals_privApubB() {
+    public void sharedKeyPubaprivbEqualsPrivapubb() {
 
         final Key sharedKey = kalium.computeSharedKey(keypairOne.getPublicKey(), keypairTwo.getPrivateKey());
 
@@ -39,7 +39,7 @@ public class KaliumIT {
     }
 
     @Test
-    public void encrypt_and_decrypt_payload_using_same_keys() {
+    public void encryptAndDecryptPayloadUsingSameKeys() {
         final String payload = "Hello world";
 
         final Key sharedKey = kalium.computeSharedKey(keypairOne.getPublicKey(), keypairTwo.getPrivateKey());
@@ -55,7 +55,7 @@ public class KaliumIT {
     }
 
     @Test
-    public void encrypt_decrpyt_without_precomputation() {
+    public void encryptDecrpytWithoutPrecomputation() {
         final String payload = "Hello world";
 
         final byte[] payloadBytes = payload.getBytes(UTF_8);

--- a/nexus-app/src/test/java/com/github/nexus/encryption/KaliumTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/encryption/KaliumTest.java
@@ -45,7 +45,7 @@ public class KaliumTest {
     }
 
     @Test
-    public void sodium_is_initialised_on_startup() {
+    public void sodiumIsInitialisedOnStartup() {
         final NaCl.Sodium sodium = mock(NaCl.Sodium.class);
 
         final Kalium kalium = new Kalium(sodium);
@@ -54,7 +54,7 @@ public class KaliumTest {
     }
 
     @Test
-    public void computing_shared_key_throws_exception_on_failure() {
+    public void computingSharedKeyThrowsExceptionOnFailure() {
         doReturn(-1)
                 .when(this.sodium)
                 .crypto_box_curve25519xsalsa20poly1305_beforenm(any(byte[].class), eq(publicKey.getKeyBytes()), eq(privateKey.getKeyBytes()));
@@ -67,7 +67,7 @@ public class KaliumTest {
     }
 
     @Test
-    public void seal_using_keys_throws_exception_on_failure() {
+    public void sealUsingKeysThrowsExceptionOnFailure() {
         doReturn(-1)
                 .when(this.sodium)
                 .crypto_box_curve25519xsalsa20poly1305(
@@ -84,7 +84,7 @@ public class KaliumTest {
     }
 
     @Test
-    public void open_using_keys_throws_exception_on_failure() {
+    public void openUsingKeysThrowsExceptionOnFailure() {
         doReturn(-1)
                 .when(this.sodium)
                 .crypto_box_curve25519xsalsa20poly1305_open(
@@ -101,7 +101,7 @@ public class KaliumTest {
     }
 
     @Test
-    public void seal_using_sharedkey_throws_exception_on_failure() {
+    public void sealUsingSharedkeyThrowsExceptionOnFailure() {
         doReturn(-1)
                 .when(this.sodium)
                 .crypto_box_curve25519xsalsa20poly1305_afternm(
@@ -118,7 +118,7 @@ public class KaliumTest {
     }
 
     @Test
-    public void open_using_sharedkey_throws_exception_on_failure() {
+    public void openUsingSharedkeyThrowsExceptionOnFailure() {
         doReturn(-1)
                 .when(this.sodium)
                 .crypto_box_curve25519xsalsa20poly1305_open_afternm(
@@ -135,14 +135,14 @@ public class KaliumTest {
     }
 
     @Test
-    public void nonce_contains_random_data() {
+    public void nonceContainsRandomData() {
         this.kalium.randomNonce();
 
         verify(this.sodium).randombytes(any(byte[].class), anyInt());
     }
 
     @Test
-    public void generating_new_keys_throws_exception_on_failure() {
+    public void generatingNewKeysThrowsExceptionOnFailure() {
         doReturn(-1)
                 .when(this.sodium)
                 .crypto_box_curve25519xsalsa20poly1305_keypair(any(byte[].class), any(byte[].class));


### PR DESCRIPTION
Make test method names use camel case instead of underscores in preparation for the check-style plugin