### PR TITLE
Swap Enclave and TransactionService methods

### DIFF
--- a/nexus-app/src/main/java/com/github/nexus/enclave/Enclave.java
+++ b/nexus-app/src/main/java/com/github/nexus/enclave/Enclave.java
@@ -1,10 +1,6 @@
 package com.github.nexus.enclave;
 
-import com.github.nexus.enclave.keys.model.Key;
 import com.github.nexus.enclave.model.MessageHash;
-
-import java.util.Collection;
-import java.util.Map;
 
 public interface Enclave {
 
@@ -22,58 +18,21 @@ public interface Enclave {
     boolean delete(MessageHash hash);
 
     /**
-     * Retrieves all payloads that the provided key is a recipient to
-     *
-     * @param recipientPublicKey The key for which to search over
-     * @return The list of all payloads that have the given key as a recipient
+     * Sends a new transaction to the enclave for storage and propagation to the provided list of recipients
+     * @param from sender node identification.
+     * @param recipients a list of the recipient nodes.
+     * @param payload transaction payload data we wish to store.
+     * @return a hash key. This key can be used to retrieve the submitted transaction
      */
-    Collection<String> retrieveAllForRecipient(Key recipientPublicKey);
+    byte[] send(byte[] from, byte[][] recipients, byte[] payload);
 
     /**
-     * Retrieves the message specified by the provided hash,
-     * and checks the intended recipient is present in the recipient list
-     *
-     * @param hash              The hash of the message to retrieve
-     * @param intendedRecipient The public key of a recipient to check is present
-     * @return The encrypted payload if the recipient is present
-     * @throws NullPointerException if the hash or intended recipient is null
-     * @throws RuntimeException     if the provided recipient is not on the message recipient list
+     * Retrieve a particular transaction
+     * @param key hash key used to retrieve transaction
+     * @param to the recipient of the transaction
+     * @return the raw payload associated with the request.
      */
-    String retrievePayload(MessageHash hash, Key intendedRecipient);
-
-    /**
-     * Retrieves the message specified by the provided hash,
-     * and uses the provided key as the sender of the message
-     *
-     * @param hash   The hash of the message to retrieve
-     * @param sender The public key of the sender to use
-     * @return The encrypted payload if the sender keys match
-     * @throws NullPointerException if the hash or sender is null
-     * @throws RuntimeException     if the provided sender is not the original sender of the message
-     */
-    String retrieve(MessageHash hash, Key sender);
-
-    /**
-     * Store the sealed payload in the database that was propagated to from another node
-     *
-     * @param sealedPayload the encrypted and encoded payload
-     * @return The hash of the sealed payload
-     */
-    MessageHash storePayloadFromOtherNode(byte[] sealedPayload);
-
-    /**
-     * Encrypts the payload using each of the given recipient keys and a random nonce
-     * against the given sender's public key.
-     * <p>
-     * Produces a result that maps the given recipient key and nonce value against the resulting ciphertext
-     *
-     * @param message             The message to be encrypted
-     * @param senderPublicKey     The public key of the sender
-     * @param recipientPublicKeys The list of public keys that are recipients of the this message
-     * @return A map of keys to nonces to cipher texts
-     */
-    Map<Key, Map<byte[], byte[]>> encryptPayload(byte[] message, Key senderPublicKey, Collection<Key> recipientPublicKeys);
-
+    byte[] receive(byte[] key, byte[] to);
 
     byte[] store(byte[] sender, byte[][] recipients, byte[] message);
 }

--- a/nexus-app/src/main/java/com/github/nexus/enclave/EnclaveImpl.java
+++ b/nexus-app/src/main/java/com/github/nexus/enclave/EnclaveImpl.java
@@ -1,50 +1,33 @@
 package com.github.nexus.enclave;
 
-import com.github.nexus.dao.EncryptedTransactionDAO;
-import com.github.nexus.enclave.keys.model.Key;
 import com.github.nexus.enclave.model.MessageHash;
-
-import java.util.Collection;
-import java.util.Map;
+import com.github.nexus.service.TransactionService;
 
 import static java.util.Objects.requireNonNull;
 
 public class EnclaveImpl implements Enclave {
 
-    private final EncryptedTransactionDAO encryptedTransactionDAO;
+    private final TransactionService transactionService;
 
-    public EnclaveImpl(final EncryptedTransactionDAO encryptedTransactionDAO) {
-        this.encryptedTransactionDAO = requireNonNull(encryptedTransactionDAO,"dao cannot be null");
+    public EnclaveImpl(final TransactionService transactionService) {
+        this.transactionService = requireNonNull(transactionService,"transaction service cannot be null");
     }
 
     @Override
     public boolean delete(final MessageHash hash) {
-        return encryptedTransactionDAO.delete(hash);
+        return transactionService.delete(hash);
     }
 
     @Override
-    public Collection<String> retrieveAllForRecipient(final Key recipientPublicKey) {
-        return null;
+    public byte[] send(byte[] from, byte[][] to, byte[] payload){
+//        transactionService.(new EncryptedTransaction("someValue".getBytes(), "somePayload".getBytes()));
+        return "mykey".getBytes();
     }
 
     @Override
-    public String retrievePayload(final MessageHash hash, final Key intendedRecipient) {
-        return null;
-    }
-
-    @Override
-    public String retrieve(final MessageHash hash, final Key sender) {
-        return null;
-    }
-
-    @Override
-    public MessageHash storePayloadFromOtherNode(final byte[] sealedPayload) {
-        return null;
-    }
-
-    @Override
-    public Map<Key, Map<byte[], byte[]>> encryptPayload(final byte[] message, final Key senderPublicKey, final Collection<Key> recipientPublicKeys) {
-        return null;
+    public byte[] receive(byte[] key, byte[] to) {
+//        transactionService.retrieveAllTransactions();
+        return "payload".getBytes();
     }
 
     @Override

--- a/nexus-app/src/main/java/com/github/nexus/service/TransactionService.java
+++ b/nexus-app/src/main/java/com/github/nexus/service/TransactionService.java
@@ -1,23 +1,77 @@
 package com.github.nexus.service;
 
+import com.github.nexus.enclave.keys.model.Key;
+import com.github.nexus.enclave.model.MessageHash;
+
+import java.util.Collection;
+import java.util.Map;
+
 public interface TransactionService {
 
     /**
-     * Sends a new transaction to the enclave for storage and propagation to the provided list of recipients
-     * @param from sender node identification.
-     * @param recipients a list of the recipient nodes.
-     * @param payload transaction payload data we wish to store.
-     * @return a hash key. This key can be used to retrieve the submitted transaction
+     * Deletes a particular transaction from the enclave
+     * Returns whether the desired state was achieved
+     * i.e. {@code true} if the message no longer exists, {@code false} if the message still exists
+     * <p>
+     * Note that the method will return true if trying to delete a non-existant message,
+     * since the desired state of the message no longer existing is satisfied
+     *
+     * @param hash The hash of the payload that should be deleted
+     * @return States whether the delete operation was successful
      */
-    byte[] send(byte[] from, byte[][] recipients, byte[] payload);
-
+    boolean delete(MessageHash hash);
 
     /**
-     * Retrieve a particular transaction
-     * @param key hash key used to retrieve transaction
-     * @param to the recipient of the transaction
-     * @return the raw payload associated with the request.
+     * Retrieves all payloads that the provided key is a recipient to
+     *
+     * @param recipientPublicKey The key for which to search over
+     * @return The list of all payloads that have the given key as a recipient
      */
-    byte[] receive(byte[] key, byte[] to);
+    Collection<String> retrieveAllForRecipient(Key recipientPublicKey);
+
+    /**
+     * Retrieves the message specified by the provided hash,
+     * and checks the intended recipient is present in the recipient list
+     *
+     * @param hash              The hash of the message to retrieve
+     * @param intendedRecipient The public key of a recipient to check is present
+     * @return The encrypted payload if the recipient is present
+     * @throws NullPointerException if the hash or intended recipient is null
+     * @throws RuntimeException     if the provided recipient is not on the message recipient list
+     */
+    String retrievePayload(MessageHash hash, Key intendedRecipient);
+
+    /**
+     * Retrieves the message specified by the provided hash,
+     * and uses the provided key as the sender of the message
+     *
+     * @param hash   The hash of the message to retrieve
+     * @param sender The public key of the sender to use
+     * @return The encrypted payload if the sender keys match
+     * @throws NullPointerException if the hash or sender is null
+     * @throws RuntimeException     if the provided sender is not the original sender of the message
+     */
+    String retrieve(MessageHash hash, Key sender);
+
+    /**
+     * Store the sealed payload in the database that was propagated to from another node
+     *
+     * @param sealedPayload the encrypted and encoded payload
+     * @return The hash of the sealed payload
+     */
+    MessageHash storePayloadFromOtherNode(byte[] sealedPayload);
+
+    /**
+     * Encrypts the payload using each of the given recipient keys and a random nonce
+     * against the given sender's public key.
+     * <p>
+     * Produces a result that maps the given recipient key and nonce value against the resulting ciphertext
+     *
+     * @param message             The message to be encrypted
+     * @param senderPublicKey     The public key of the sender
+     * @param recipientPublicKeys The list of public keys that are recipients of the this message
+     * @return A map of keys to nonces to cipher texts
+     */
+    Map<Key, Map<byte[], byte[]>> encryptPayload(byte[] message, Key senderPublicKey, Collection<Key> recipientPublicKeys);
 
 }

--- a/nexus-app/src/main/java/com/github/nexus/service/TransactionServiceImpl.java
+++ b/nexus-app/src/main/java/com/github/nexus/service/TransactionServiceImpl.java
@@ -1,9 +1,12 @@
 package com.github.nexus.service;
 
 import com.github.nexus.dao.EncryptedTransactionDAO;
-import com.github.nexus.entity.EncryptedTransaction;
+import com.github.nexus.enclave.keys.model.Key;
+import com.github.nexus.enclave.model.MessageHash;
 
 import javax.transaction.Transactional;
+import java.util.Collection;
+import java.util.Map;
 import java.util.logging.Logger;
 
 @Transactional
@@ -18,15 +21,33 @@ public class TransactionServiceImpl implements TransactionService{
     }
 
     @Override
-    public byte[] send(byte[] from, byte[][] to, byte[] payload){
-        encryptedTransactionDAO.save(new EncryptedTransaction("someValue".getBytes(), "somePayload".getBytes()));
-        return "mykey".getBytes();
+    public boolean delete(final MessageHash hash) {
+        return encryptedTransactionDAO.delete(hash);
     }
 
     @Override
-    public byte[] receive(byte[] key, byte[] to) {
-        LOGGER.info("receive");
-        encryptedTransactionDAO.retrieveAllTransactions();
-        return "payload".getBytes();
+    public Collection<String> retrieveAllForRecipient(final Key recipientPublicKey) {
+        return null;
     }
+
+    @Override
+    public String retrievePayload(final MessageHash hash, final Key intendedRecipient) {
+        return null;
+    }
+
+    @Override
+    public String retrieve(final MessageHash hash, final Key sender) {
+        return null;
+    }
+
+    @Override
+    public MessageHash storePayloadFromOtherNode(final byte[] sealedPayload) {
+        return null;
+    }
+
+    @Override
+    public Map<Key, Map<byte[], byte[]>> encryptPayload(final byte[] message, final Key senderPublicKey, final Collection<Key> recipientPublicKeys) {
+        return null;
+    }
+
 }

--- a/nexus-app/src/test/java/com/github/nexus/enclave/EnclaveImplTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/enclave/EnclaveImplTest.java
@@ -1,54 +1,42 @@
 package com.github.nexus.enclave;
 
-import com.github.nexus.dao.EncryptedTransactionDAO;
-import com.github.nexus.enclave.keys.model.Key;
 import com.github.nexus.enclave.model.MessageHash;
+import com.github.nexus.service.TransactionService;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class EnclaveImplTest {
 
-    private EncryptedTransactionDAO dao;
+    private TransactionService txService;
 
     private Enclave enclave;
 
     @Before
     public void setUp(){
-        this.dao = mock(EncryptedTransactionDAO.class);
-        enclave = new EnclaveImpl(dao);
+        this.txService = mock(TransactionService.class);
+        enclave = new EnclaveImpl(txService);
     }
-
 
     @Test
     public void testDelete(){
-        when(dao.delete(any())).thenReturn(true);
+        doReturn(true).when(txService).delete(any(MessageHash.class));
+
         enclave.delete(new MessageHash(new byte[0]));
-        verify(dao, times(1)).delete(any());
+
+        verify(txService).delete(any(MessageHash.class));
     }
 
     @Test
-    public void testRetrieveAllForRecipient(){
-        enclave.retrieveAllForRecipient(new Key(new byte[0]));
+    public void testSend(){
+        enclave.send(new byte[0], new byte[0][0], new byte[0]);
     }
 
     @Test
-    public void testRetrievePayload(){
-        enclave.retrievePayload(new MessageHash(new byte[0]), new Key(new byte[0]));
-    }
-
-    @Test
-    public void testRetrieve(){
-        enclave.retrieve(new MessageHash(new byte[0]), new Key(new byte[0]));
-    }
-
-    @Test
-    public void testStorePayloadFromOtherNode(){
-        enclave.storePayloadFromOtherNode(new byte[0]);
+    public void testReceive(){
+        enclave.receive(new byte[0], new byte[0]);
     }
 
     @Test
@@ -56,8 +44,4 @@ public class EnclaveImplTest {
         enclave.store(new byte[0], new byte[0][0], new byte[0]);
     }
 
-    @Test
-    public void testEncryptPayload(){
-        enclave.encryptPayload(new byte[0], new Key(new byte[0]), Collections.EMPTY_LIST);
-    }
 }

--- a/nexus-app/src/test/java/com/github/nexus/service/TransactionServiceTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/service/TransactionServiceTest.java
@@ -1,13 +1,15 @@
 package com.github.nexus.service;
 
 import com.github.nexus.dao.EncryptedTransactionDAO;
+import com.github.nexus.enclave.keys.model.Key;
+import com.github.nexus.enclave.model.MessageHash;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class TransactionServiceTest {
 
@@ -16,20 +18,40 @@ public class TransactionServiceTest {
     private TransactionService transactionService;
 
     @Before
-    public void init(){
+    public void init() {
         this.dao = mock(EncryptedTransactionDAO.class);
-        transactionService = new TransactionServiceImpl(dao);
+        this.transactionService = new TransactionServiceImpl(dao);
     }
 
     @Test
-    public void testSend(){
-        transactionService.send(new byte[0], new byte[0][0], new byte[0]);
-        verify(dao, times((1))).save(any());
+    public void testDelete(){
+        when(dao.delete(any())).thenReturn(true);
+        transactionService.delete(new MessageHash(new byte[0]));
+        verify(dao, times(1)).delete(any());
     }
 
     @Test
-    public void testReceive(){
-        transactionService.receive(new byte[0], new byte[0]);
-        verify(dao, times(1)).retrieveAllTransactions();
+    public void testRetrieveAllForRecipient(){
+        transactionService.retrieveAllForRecipient(new Key(new byte[0]));
+    }
+
+    @Test
+    public void testRetrievePayload(){
+        transactionService.retrievePayload(new MessageHash(new byte[0]), new Key(new byte[0]));
+    }
+
+    @Test
+    public void testRetrieve(){
+        transactionService.retrieve(new MessageHash(new byte[0]), new Key(new byte[0]));
+    }
+
+    @Test
+    public void testStorePayloadFromOtherNode(){
+        transactionService.storePayloadFromOtherNode(new byte[0]);
+    }
+
+    @Test
+    public void testEncryptPayload(){
+        transactionService.encryptPayload(new byte[0], new Key(new byte[0]), Collections.EMPTY_LIST);
     }
 }


### PR DESCRIPTION
The Enclave and TransactionService have swapped names, but not roles.
The methods from each have been swapped over so that each class maintains in previous role but with the new name.