### PR TITLE
Added JNaCL, a pure Java implementation of the NaCL standard.

### DIFF
--- a/nexus-encryption-jnacl/pom.xml
+++ b/nexus-encryption-jnacl/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>nexus-encryption-jnacl</artifactId>
+
+    <name>nexus-encryption-jnacl</name>
+    <packaging>jar</packaging>
+
+    <parent>
+        <artifactId>nexus</artifactId>
+        <groupId>com.github.nexus</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <dependencyManagement>
+
+        <dependencies>
+
+            <dependency>
+                <groupId>eu.neilalexander</groupId>
+                <artifactId>jnacl</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+
+        </dependencies>
+
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.github.nexus</groupId>
+            <artifactId>nexus-encryption</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>eu.neilalexander</groupId>
+            <artifactId>jnacl</artifactId>
+        </dependency>
+
+    </dependencies>
+
+
+
+</project>

--- a/nexus-encryption-jnacl/src/main/java/com/github/nexus/nacl/jnacl/Jnacl.java
+++ b/nexus-encryption-jnacl/src/main/java/com/github/nexus/nacl/jnacl/Jnacl.java
@@ -1,0 +1,251 @@
+package com.github.nexus.nacl.jnacl;
+
+import com.github.nexus.nacl.*;
+import com.neilalexander.jnacl.NaCl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static com.neilalexander.jnacl.crypto.curve25519xsalsa20poly1305.*;
+
+public class Jnacl implements NaclFacade {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Jnacl.class);
+
+    private final SecureRandom secureRandom;
+
+    private final SecretBox secretBox;
+
+    public Jnacl(final SecureRandom secureRandom, final SecretBox secretBox) {
+        this.secureRandom = Objects.requireNonNull(secureRandom);
+        this.secretBox = Objects.requireNonNull(secretBox);
+    }
+
+    @Override
+    public Key computeSharedKey(final Key publicKey, final Key privateKey) {
+        final byte[] precomputed = new byte[crypto_secretbox_BEFORENMBYTES];
+
+        LOGGER.info("Computing the shared key for public key {} and private key {}", publicKey, "REDACTED");
+        LOGGER.debug("Computing the shared key for public key {} and private key {}", publicKey, privateKey);
+        final int jnaclResult = secretBox.cryptoBoxBeforenm(
+            precomputed, publicKey.getKeyBytes(), privateKey.getKeyBytes()
+        );
+
+        if(jnaclResult == -1) {
+            LOGGER.warn("Could not compute the shared key for pub {} and priv {}", publicKey, "REDACTED");
+            LOGGER.debug("Could not compute the shared key for pub {} and priv {}", publicKey, privateKey);
+            throw new NaclException("Kalium could not compute the shared key");
+        }
+
+        final Key sharedKey = new Key(precomputed);
+
+        LOGGER.info("Computed shared key {} for pub {} and priv {}", sharedKey, publicKey, "REDACTED");
+        LOGGER.debug("Computed shared key {} for pub {} and priv {}", sharedKey, publicKey, privateKey);
+
+        return sharedKey;
+
+    }
+
+    @Override
+    public byte[] seal(final byte[] message, final Nonce nonce, final Key publicKey, final Key privateKey) {
+
+        LOGGER.info("Sealing message using public key {}", publicKey);
+        LOGGER.debug(
+            "Sealing message {} using nonce {}, public key {} and private key {}",
+            Arrays.toString(message), nonce, publicKey, privateKey
+        );
+
+        try {
+
+            final NaCl nacl = new NaCl(privateKey.getKeyBytes(), publicKey.getKeyBytes());
+
+            final byte[] cipherText = nacl.encrypt(message, nonce.getNonceBytes());
+
+            LOGGER.info("Created sealed payload for public key {}", publicKey);
+            LOGGER.debug(
+                "Created sealed payload {} using nonce {}, public key {} and private key {}",
+                Arrays.toString(cipherText), nonce, publicKey, privateKey
+            );
+
+            return extract(cipherText, crypto_secretbox_BOXZEROBYTES);
+
+        } catch (final Exception ex) {
+            throw new NaclException(ex.getMessage());
+        }
+
+    }
+
+    @Override
+    public byte[] open(final byte[] cipherText, final Nonce nonce, final Key publicKey, final Key privateKey) {
+        LOGGER.info("Opening message using public key {}", publicKey);
+        LOGGER.debug(
+            "Opening message {} using nonce {}, public key {} and private key {}",
+            Arrays.toString(cipherText), nonce, publicKey, privateKey
+        );
+
+        try {
+
+            final byte[] paddedInput = pad(cipherText, crypto_secretbox_BOXZEROBYTES);
+
+            final NaCl nacl = new NaCl(privateKey.getKeyBytes(), publicKey.getKeyBytes());
+
+            final byte[] plaintext = nacl.decrypt(paddedInput, nonce.getNonceBytes());
+
+            LOGGER.info("Created sealed payload for public key {}", publicKey);
+            LOGGER.debug(
+                "Created sealed payload {} using nonce {}, public key {} and private key {}",
+                Arrays.toString(cipherText), nonce, publicKey, privateKey
+            );
+
+            return plaintext;
+        } catch (final Exception ex) {
+            throw new NaclException(ex.getMessage());
+        }
+    }
+
+    @Override
+    public byte[] sealAfterPrecomputation(final byte[] message, final Nonce nonce, final Key sharedKey) {
+
+        final byte[] paddedMessage = new byte[message.length + crypto_secretbox_ZEROBYTES];
+        final byte[] output = new byte[message.length + crypto_secretbox_ZEROBYTES];
+
+        LOGGER.info("Sealing message using public key {}", sharedKey);
+        LOGGER.debug(
+            "Sealing message {} using nonce {} and shared key {}",
+            Arrays.toString(message), nonce, sharedKey
+        );
+
+        System.arraycopy(message, 0, paddedMessage, crypto_secretbox_ZEROBYTES, message.length);
+        final int jnaclResult = secretBox.cryptoBoxAfternm(
+            output, paddedMessage, paddedMessage.length, nonce.getNonceBytes(), sharedKey.getKeyBytes()
+        );
+
+        if(jnaclResult == -1) {
+            LOGGER.warn("Could not create sealed payload using shared key {}", sharedKey);
+            LOGGER.debug("Could not create sealed payload using shared key {}", sharedKey);
+            throw new NaclException("Kalium could not seal the payload using the shared key");
+        }
+
+        LOGGER.info("Created sealed payload for shared key {}", sharedKey);
+        LOGGER.debug(
+            "Created sealed payload {} using nonce {} and shared key {}",
+            Arrays.toString(output), nonce, sharedKey
+        );
+
+        return extract(output, crypto_secretbox_BOXZEROBYTES);
+    }
+
+    @Override
+    public byte[] openAfterPrecomputation(final byte[] cipherText, final Nonce nonce, final Key sharedKey) {
+        LOGGER.info("Opening message using shared key {}", sharedKey);
+        LOGGER.debug(
+            "Opening message {} using nonce {} and shared key {}",
+            Arrays.toString(cipherText), nonce, sharedKey
+        );
+
+        final byte[] paddedInput = pad(cipherText, crypto_secretbox_BOXZEROBYTES);
+        final byte[] paddedOutput = new byte[paddedInput.length];
+
+        final int jnaclResult = secretBox.cryptoBoxOpenAfternm(
+            paddedOutput, paddedInput, paddedInput.length, nonce.getNonceBytes(), sharedKey.getKeyBytes()
+        );
+
+        if(jnaclResult == -1) {
+            LOGGER.warn("Could not open sealed payload using shared key {}", sharedKey);
+            LOGGER.debug("Could not open sealed payload using shared key {}", sharedKey);
+            throw new NaclException("Kalium could not open the payload using the shared key");
+        }
+
+        LOGGER.info("Opened sealed payload for shared key {}", sharedKey);
+        LOGGER.debug(
+            "Opened payload {} using nonce {}, public key {} and private key {} to get result {}",
+            Arrays.toString(cipherText), nonce, sharedKey, Arrays.toString(paddedOutput)
+        );
+
+        return extract(paddedOutput, crypto_secretbox_ZEROBYTES);
+    }
+
+    @Override
+    public Nonce randomNonce() {
+        final byte[] nonceBytes = new byte[crypto_secretbox_NONCEBYTES];
+
+        this.secureRandom.nextBytes(nonceBytes);
+
+        final Nonce nonce = new Nonce(nonceBytes);
+
+        LOGGER.debug("Generated random nonce {}", nonce);
+
+        return nonce;
+    }
+
+    @Override
+    public KeyPair generateNewKeys() {
+        final byte[] publicKey = new byte[crypto_secretbox_PUBLICKEYBYTES];
+        final byte[] privateKey = new byte[crypto_secretbox_SECRETKEYBYTES];
+
+        LOGGER.info("Generating new keypair...");
+
+        final int jnaclResult = secretBox.cryptoBoxKeypair(publicKey, privateKey);
+
+        if(jnaclResult == -1) {
+            LOGGER.warn("Unable to generate a new keypair!");
+            throw new NaclException("JNaCL could not generate a new public/private keypair");
+        }
+
+        final Key pubKey = new Key(publicKey);
+        final Key privKey = new Key(privateKey);
+
+        LOGGER.info("Generated public key {} and private key {}", pubKey, "REDACTED");
+        LOGGER.debug("Generated public key {} and private key {}", pubKey, privKey);
+
+        return new KeyPair(pubKey, privKey);
+    }
+
+    @Override
+    public Key createSingleKey() {
+        LOGGER.info("Generating random key");
+
+        final byte[] keyBytes = new byte[crypto_secretbox_PUBLICKEYBYTES];
+
+        this.secureRandom.nextBytes(keyBytes);
+
+        final Key key = new Key(keyBytes);
+
+        LOGGER.info("Random key generated");
+        LOGGER.debug("Generated key with value {}", key);
+
+        return key;
+    }
+
+    /**
+     * Left-pads a given message with padSize amount of zeros
+     *
+     * @param input the message to be padded
+     * @param padSize the amount of left-padding to apply
+     * @return the padded message
+     */
+    private byte[] pad(final byte[] input, final int padSize) {
+        final byte[] paddedMessage = new byte[padSize + input.length];
+        System.arraycopy(input, 0, paddedMessage, padSize, input.length);
+
+        return paddedMessage;
+    }
+
+    /**
+     * Removes left-padding from a given message to tune of padSize
+     *
+     * @param input The message from which to remove left-padding
+     * @param padSize The amount of left-padding to remove
+     * @return The trimmed message
+     */
+    private byte[] extract(final byte[] input, final int padSize) {
+        final byte[] extractedMessage = new byte[input.length - padSize];
+        System.arraycopy(input, padSize, extractedMessage, 0, extractedMessage.length);
+
+        return extractedMessage;
+    }
+
+}

--- a/nexus-encryption-jnacl/src/main/java/com/github/nexus/nacl/jnacl/JnaclFactory.java
+++ b/nexus-encryption-jnacl/src/main/java/com/github/nexus/nacl/jnacl/JnaclFactory.java
@@ -1,0 +1,18 @@
+package com.github.nexus.nacl.jnacl;
+
+import com.github.nexus.nacl.NaclFacade;
+import com.github.nexus.nacl.NaclFacadeFactory;
+
+import java.security.SecureRandom;
+
+public class JnaclFactory implements NaclFacadeFactory {
+
+    @Override
+    public NaclFacade create() {
+        final SecureRandom secureRandom = new SecureRandom();
+        final JnaclSecretBox secretBox = new JnaclSecretBox();
+
+        return new Jnacl(secureRandom, secretBox);
+    }
+
+}

--- a/nexus-encryption-jnacl/src/main/java/com/github/nexus/nacl/jnacl/JnaclSecretBox.java
+++ b/nexus-encryption-jnacl/src/main/java/com/github/nexus/nacl/jnacl/JnaclSecretBox.java
@@ -1,0 +1,27 @@
+package com.github.nexus.nacl.jnacl;
+
+import com.neilalexander.jnacl.crypto.curve25519xsalsa20poly1305;
+
+public class JnaclSecretBox implements SecretBox {
+
+    @Override
+    public int cryptoBoxBeforenm(final byte[] output, final byte[] publicKey, final byte[] privateKey) {
+        return curve25519xsalsa20poly1305.crypto_box_beforenm(output, publicKey, privateKey);
+    }
+
+    @Override
+    public int cryptoBoxAfternm(final byte[] output, final byte[] message, final int messageLength, final byte[] nonce, final byte[] sharedKey) {
+        return curve25519xsalsa20poly1305.crypto_box_afternm(output, message, messageLength, nonce, sharedKey);
+    }
+
+    @Override
+    public int cryptoBoxOpenAfternm(final byte[] output, final byte[] message, final int messageLength, final byte[] nonce, final byte[] sharedKey) {
+        return curve25519xsalsa20poly1305.crypto_box_open_afternm(output, message, messageLength, nonce, sharedKey);
+    }
+
+    @Override
+    public int cryptoBoxKeypair(final byte[] publicKey, final byte[] privateKey) {
+        return curve25519xsalsa20poly1305.crypto_box_keypair(publicKey, privateKey);
+    }
+
+}

--- a/nexus-encryption-jnacl/src/main/java/com/github/nexus/nacl/jnacl/SecretBox.java
+++ b/nexus-encryption-jnacl/src/main/java/com/github/nexus/nacl/jnacl/SecretBox.java
@@ -1,0 +1,13 @@
+package com.github.nexus.nacl.jnacl;
+
+public interface SecretBox {
+
+    int cryptoBoxBeforenm(byte[] output, byte[] publicKey, byte[] privateKey);
+
+    int cryptoBoxAfternm(byte[] output, byte[] message, int messageLength, byte[] nonce, byte[] sharedKey);
+
+    int cryptoBoxOpenAfternm(byte[] output, byte[] message, int messageLength, byte[] nonce, byte[] sharedKey);
+
+    int cryptoBoxKeypair(byte[] publicKey, byte[] privateKey);
+
+}

--- a/nexus-encryption-jnacl/src/main/resources/META-INF/services/com.github.nexus.nacl.NaclFacadeFactory
+++ b/nexus-encryption-jnacl/src/main/resources/META-INF/services/com.github.nexus.nacl.NaclFacadeFactory
@@ -1,0 +1,1 @@
+com.github.nexus.nacl.jnacl.JnaclFactory

--- a/nexus-encryption-jnacl/src/test/java/com/github/nexus/nacl/jnacl/JnaclFactoryTest.java
+++ b/nexus-encryption-jnacl/src/test/java/com/github/nexus/nacl/jnacl/JnaclFactoryTest.java
@@ -1,0 +1,25 @@
+package com.github.nexus.nacl.jnacl;
+
+import com.github.nexus.nacl.NaclFacade;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JnaclFactoryTest {
+
+    private JnaclFactory jnaclFactory;
+
+    @Before
+    public void setUp() {
+        this.jnaclFactory = new JnaclFactory();
+    }
+
+    @Test
+    public void createInstance() {
+        final NaclFacade result = jnaclFactory.create();
+
+        assertThat(result).isNotNull().isExactlyInstanceOf(Jnacl.class);
+    }
+
+}

--- a/nexus-encryption-jnacl/src/test/java/com/github/nexus/nacl/jnacl/JnaclIT.java
+++ b/nexus-encryption-jnacl/src/test/java/com/github/nexus/nacl/jnacl/JnaclIT.java
@@ -1,0 +1,88 @@
+package com.github.nexus.nacl.jnacl;
+
+import com.github.nexus.nacl.Key;
+import com.github.nexus.nacl.KeyPair;
+import com.github.nexus.nacl.Nonce;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.SecureRandom;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JnaclIT {
+
+    private KeyPair keypairOne;
+
+    private KeyPair keypairTwo;
+
+    private Jnacl jnacl;
+
+    @Before
+    public void init() {
+        this.jnacl = new Jnacl(new SecureRandom(), new JnaclSecretBox());
+
+        this.keypairOne = jnacl.generateNewKeys();
+        this.keypairTwo = jnacl.generateNewKeys();
+    }
+
+    @Test
+    public void sharedKeyPubaprivbEqualsPrivapubb() {
+
+        final Key sharedKey = jnacl.computeSharedKey(keypairOne.getPublicKey(), keypairTwo.getPrivateKey());
+
+        final Key secondSharedKey = jnacl.computeSharedKey(keypairTwo.getPublicKey(), keypairOne.getPrivateKey());
+
+        assertThat(sharedKey).isEqualTo(secondSharedKey);
+
+    }
+
+    @Test
+    public void encryptAndDecryptPayloadUsingSameKeys() {
+        final String payload = "Hello world";
+
+        final Key sharedKey = jnacl.computeSharedKey(keypairOne.getPublicKey(), keypairTwo.getPrivateKey());
+        final byte[] payloadBytes = payload.getBytes(UTF_8);
+        final Nonce nonce = jnacl.randomNonce();
+
+        final byte[] encryptedPayload = jnacl.sealAfterPrecomputation(payloadBytes, nonce, sharedKey);
+        final byte[] decryptedPayload = jnacl.openAfterPrecomputation(encryptedPayload, nonce, sharedKey);
+
+        final String decryptedMessage = new String(decryptedPayload, UTF_8);
+
+        assertThat(decryptedMessage).isEqualTo(payload);
+    }
+
+    @Test
+    public void encryptDecrpytWithoutPrecomputation() {
+        final String payload = "Hello world";
+
+        final byte[] payloadBytes = payload.getBytes(UTF_8);
+        final Nonce nonce = jnacl.randomNonce();
+
+        final byte[] encryptedPayload = jnacl.seal(payloadBytes, nonce, keypairOne.getPublicKey(), keypairTwo.getPrivateKey());
+        final byte[] decryptedPayload = jnacl.open(encryptedPayload, nonce, keypairTwo.getPublicKey(), keypairOne.getPrivateKey());
+
+        final String decryptedMessage = new String(decryptedPayload, UTF_8);
+
+        assertThat(decryptedMessage).isEqualTo(payload);
+    }
+
+    @Test
+    public void randomKeyCanEncryptAndDecrpytPayload() {
+
+        final String payload = "Hello world";
+        final byte[] payloadBytes = payload.getBytes(UTF_8);
+        final Nonce nonce = jnacl.randomNonce();
+
+        final Key symmentricKey = jnacl.createSingleKey();
+
+        final byte[] encryptedPayload = jnacl.sealAfterPrecomputation(payloadBytes, nonce, symmentricKey);
+        final byte[] decryptedPayload = jnacl.openAfterPrecomputation(encryptedPayload, nonce, symmentricKey);
+
+        final String decryptedMessage = new String(decryptedPayload, UTF_8);
+        assertThat(decryptedMessage).isEqualTo(payload);
+    }
+
+}

--- a/nexus-encryption-jnacl/src/test/java/com/github/nexus/nacl/jnacl/JnaclSecretBoxTest.java
+++ b/nexus-encryption-jnacl/src/test/java/com/github/nexus/nacl/jnacl/JnaclSecretBoxTest.java
@@ -1,0 +1,168 @@
+package com.github.nexus.nacl.jnacl;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static com.neilalexander.jnacl.crypto.curve25519xsalsa20poly1305.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class JnaclSecretBoxTest {
+
+    private JnaclSecretBox secretBox = new JnaclSecretBox();
+
+    private byte[] publicKey;
+
+    private byte[] privateKey;
+
+    @Before
+    public void init() {
+        this.publicKey = new byte[crypto_secretbox_PUBLICKEYBYTES];
+        this.privateKey = new byte[crypto_secretbox_SECRETKEYBYTES];
+
+        this.secretBox.cryptoBoxKeypair(publicKey, privateKey);
+    }
+
+    @Test
+    public void sharedKeyUsingValidKeys() {
+        final byte[] sharedKey = new byte[crypto_secretbox_BEFORENMBYTES];
+
+        final int success = this.secretBox.cryptoBoxBeforenm(sharedKey, publicKey, privateKey);
+
+        assertThat(success).isEqualTo(0);
+    }
+
+    @Test
+    public void sharedKeyFailsIfOutputTooSmall() {
+        final byte[] sharedKey = new byte[crypto_secretbox_BEFORENMBYTES-1];
+
+        final Throwable throwable = catchThrowable(
+            () -> this.secretBox.cryptoBoxBeforenm(sharedKey, publicKey, privateKey)
+        );
+
+        assertThat(throwable).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void sharedKeyFailsIfPublicKeyTooSmall() {
+        final byte[] sharedKey = new byte[crypto_secretbox_BEFORENMBYTES];
+
+        final Throwable throwable = catchThrowable(
+            () -> this.secretBox.cryptoBoxBeforenm(
+                sharedKey, Arrays.copyOf(publicKey, publicKey.length-1), privateKey
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void sharedKeyFailsIfPrivateKeyTooSmall() {
+        final byte[] sharedKey = new byte[crypto_secretbox_BEFORENMBYTES];
+
+        final Throwable throwable = catchThrowable(
+            () -> this.secretBox.cryptoBoxBeforenm(
+                sharedKey, publicKey, Arrays.copyOf(privateKey, privateKey.length-1)
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void sealingMessageUsingSymmetricKeyFailsIfMessageIsLessThanRequiredLength() {
+
+        final int success = this.secretBox
+            .cryptoBoxAfternm(new byte[0], new byte[0], 0, new byte[0], new byte[0]);
+
+        assertThat(success).isEqualTo(-1);
+
+    }
+
+    @Test
+    public void sealingMessageUsingSymmetricKeySucceeds() {
+        final int success = this.secretBox
+            .cryptoBoxAfternm(new byte[32], new byte[32], 32, new byte[24], new byte[32]);
+
+        assertThat(success).isEqualTo(0);
+    }
+
+    @Test
+    public void generatingNewKeysSucceedsIfArraysAreBigEnough() {
+        final byte[] publicKey = new byte[crypto_secretbox_PUBLICKEYBYTES];
+        final byte[] privateKey = new byte[crypto_secretbox_SECRETKEYBYTES];
+
+        final int success = this.secretBox.cryptoBoxKeypair(publicKey, privateKey);
+
+        assertThat(success).isEqualTo(0);
+    }
+
+    @Test
+    public void generatingNewsKeysFailsIfPublicKeyTooSmall() {
+
+        final byte[] publicKey = new byte[crypto_secretbox_PUBLICKEYBYTES-1];
+        final byte[] privateKey = new byte[crypto_secretbox_SECRETKEYBYTES];
+
+        final Throwable throwable = catchThrowable(() -> this.secretBox.cryptoBoxKeypair(publicKey, privateKey));
+
+        assertThat(throwable).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+
+    }
+
+    @Test
+    public void generatingNewsKeysFailsIfPrivateKeyTooSmall() {
+
+        final byte[] publicKey = new byte[crypto_secretbox_PUBLICKEYBYTES];
+        final byte[] privateKey = new byte[crypto_secretbox_SECRETKEYBYTES-1];
+
+        final Throwable throwable = catchThrowable(() -> this.secretBox.cryptoBoxKeypair(publicKey, privateKey));
+
+        assertThat(throwable).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+
+    }
+
+    @Test
+    public void openingBoxFailsIfInputLengthTooSmall() {
+
+        final int success = this.secretBox
+            .cryptoBoxOpenAfternm(new byte[0], new byte[0], 0, new byte[0], new byte[0]);
+
+        assertThat(success).isEqualTo(-1);
+
+    }
+
+    @Test
+    public void openingFailsIfInputsAreInvalid() {
+
+        final int success = this.secretBox
+            .cryptoBoxOpenAfternm(new byte[32], new byte[32], 32, new byte[24], new byte[32]);
+
+        assertThat(success).isEqualTo(-1);
+
+    }
+
+    @Test
+    public void openingSucceedsIfInputsAreValid() {
+
+        //setup
+        final byte[] sharedKey = new byte[crypto_secretbox_BEFORENMBYTES];
+        this.secretBox.cryptoBoxBeforenm(sharedKey, publicKey, privateKey);
+
+        final byte[] nonce = new byte[crypto_secretbox_NONCEBYTES];
+        final byte[] message = new byte[33];
+        message[32] = 1;
+        final byte[] cipherText = new byte[33];
+        this.secretBox.cryptoBoxAfternm(cipherText, message, 33, nonce, sharedKey);
+
+        //make the call
+        final int success = this.secretBox
+            .cryptoBoxOpenAfternm(new byte[33], cipherText, 33, nonce, sharedKey);
+
+        //check result
+        assertThat(success).isEqualTo(0);
+
+    }
+
+}

--- a/nexus-encryption-jnacl/src/test/java/com/github/nexus/nacl/jnacl/JnaclTest.java
+++ b/nexus-encryption-jnacl/src/test/java/com/github/nexus/nacl/jnacl/JnaclTest.java
@@ -1,0 +1,253 @@
+package com.github.nexus.nacl.jnacl;
+
+import com.github.nexus.nacl.Key;
+import com.github.nexus.nacl.KeyPair;
+import com.github.nexus.nacl.NaclException;
+import com.github.nexus.nacl.Nonce;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.SecureRandom;
+
+import static com.neilalexander.jnacl.crypto.curve25519xsalsa20poly1305.crypto_secretbox_BEFORENMBYTES;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class JnaclTest {
+
+    private Key publicKey;
+
+    private Key privateKey;
+
+    private Key sharedKey;
+
+    private byte[] message = "TEST_MESSAGE".getBytes(UTF_8);
+
+    private Nonce nonce = new Nonce("TEST_NONCE".getBytes(UTF_8));
+
+    private SecureRandom secureRandom;
+
+    private SecretBox secretBox;
+
+    private Jnacl jnacl;
+
+    @Before
+    public void init() {
+        this.secureRandom = new SecureRandom();
+        this.secretBox = mock(SecretBox.class);
+
+        this.jnacl = new Jnacl(this.secureRandom, this.secretBox);
+
+        final Jnacl setupJnacl = new Jnacl(new SecureRandom(), new JnaclSecretBox());
+        final KeyPair keys = setupJnacl.generateNewKeys();
+        this.publicKey = keys.getPublicKey();
+        this.privateKey = keys.getPrivateKey();
+        this.sharedKey = setupJnacl.computeSharedKey(publicKey, privateKey);
+
+        this.nonce = setupJnacl.randomNonce();
+    }
+
+    @After
+    public void after() {
+        verifyNoMoreInteractions(this.secretBox);
+    }
+
+    @Test
+    public void computingSharedKeyThrowsExceptionOnFailure() {
+        doReturn(-1)
+            .when(this.secretBox)
+            .cryptoBoxBeforenm(any(byte[].class), eq(publicKey.getKeyBytes()), eq(privateKey.getKeyBytes()));
+
+        final Throwable kaclEx = catchThrowable(() -> this.jnacl.computeSharedKey(publicKey, privateKey));
+
+        assertThat(kaclEx).isInstanceOf(NaclException.class).hasMessage("Kalium could not compute the shared key");
+
+        verify(this.secretBox).cryptoBoxBeforenm(any(byte[].class), eq(publicKey.getKeyBytes()), eq(privateKey.getKeyBytes()));
+    }
+
+    @Test
+    public void sealUsingKeysThrowsExceptionOnFailure() {
+
+        final Throwable kaclEx = catchThrowable(
+            () -> this.jnacl.seal(message, nonce, publicKey, new Key(new byte[]{}))
+        );
+
+        assertThat(kaclEx)
+            .isInstanceOf(NaclException.class)
+            .hasMessage("Private key too short");
+
+    }
+
+    @Test
+    public void openUsingKeysThrowsExceptionOnFailure() {
+        final Throwable kaclEx = catchThrowable(
+            () -> this.jnacl.open(message, nonce, publicKey, new Key(new byte[]{}))
+        );
+
+        assertThat(kaclEx)
+            .isInstanceOf(NaclException.class)
+            .hasMessage("Private key too short");
+
+    }
+
+    @Test
+    public void sealUsingSharedkeyThrowsExceptionOnFailure() {
+        doReturn(-1)
+            .when(this.secretBox)
+            .cryptoBoxAfternm(
+                any(byte[].class), any(byte[].class), anyInt(), any(byte[].class), eq(sharedKey.getKeyBytes())
+            );
+
+        final Throwable kaclEx = catchThrowable(() -> this.jnacl.sealAfterPrecomputation(message, nonce, sharedKey));
+
+        assertThat(kaclEx).isInstanceOf(NaclException.class).hasMessage("Kalium could not seal the payload using the shared key");
+
+        verify(this.secretBox).cryptoBoxAfternm(
+            any(byte[].class), any(byte[].class), anyInt(), any(byte[].class), any(byte[].class)
+        );
+    }
+
+    @Test
+    public void openUsingSharedkeyThrowsExceptionOnFailure() {
+        doReturn(-1)
+            .when(this.secretBox)
+            .cryptoBoxOpenAfternm(
+                any(byte[].class), any(byte[].class), anyInt(), any(byte[].class), eq(sharedKey.getKeyBytes())
+            );
+
+        final Throwable kaclEx = catchThrowable(() -> this.jnacl.openAfterPrecomputation(message, nonce, sharedKey));
+
+        assertThat(kaclEx).isInstanceOf(NaclException.class).hasMessage("Kalium could not open the payload using the shared key");
+
+        verify(this.secretBox).cryptoBoxOpenAfternm(
+            any(byte[].class), any(byte[].class), anyInt(), any(byte[].class), any(byte[].class)
+        );
+    }
+
+    @Test
+    public void nonceContainsRandomData() {
+        final Nonce nonce = this.jnacl.randomNonce();
+
+        assertThat(nonce.getNonceBytes()).hasSize(24);
+    }
+
+    @Test
+    public void generatingNewKeysThrowsExceptionOnFailure() {
+        doReturn(-1)
+            .when(this.secretBox)
+            .cryptoBoxKeypair(any(byte[].class), any(byte[].class));
+
+        final Throwable kaclEx = catchThrowable(() -> this.jnacl.generateNewKeys());
+
+        assertThat(kaclEx).isInstanceOf(NaclException.class).hasMessage("JNaCL could not generate a new public/private keypair");
+
+        verify(this.secretBox).cryptoBoxKeypair(any(byte[].class), any(byte[].class));
+    }
+
+    @Test
+    public void computeSharedKeySodiumReturnsSuccess() {
+
+        doReturn(1)
+            .when(this.secretBox)
+            .cryptoBoxBeforenm(any(byte[].class), any(byte[].class), any(byte[].class));
+
+        final Key result = this.jnacl.computeSharedKey(publicKey, privateKey);
+
+        assertThat(result).isNotNull();
+
+        assertThat(result.getKeyBytes())
+            .isEqualTo(new byte[crypto_secretbox_BEFORENMBYTES]);
+
+        verify(this.secretBox).cryptoBoxBeforenm(any(byte[].class), any(byte[].class), any(byte[].class));
+
+    }
+
+    @Test
+    public void generateNewKeysSodiumSuccess() {
+
+        final KeyPair result = this.jnacl.generateNewKeys();
+
+        assertThat(result).isNotNull();
+
+        assertThat(result.getPrivateKey()).isNotNull();
+        assertThat(result.getPublicKey()).isNotNull();
+
+        assertThat(result.getPublicKey().getKeyBytes()).hasSize(32);
+        assertThat(result.getPrivateKey().getKeyBytes()).hasSize(32);
+
+        verify(this.secretBox).cryptoBoxKeypair(any(byte[].class), any(byte[].class));
+
+    }
+
+    @Test
+    public void sealAfterPrecomputationSodiumReturnsSuccess() {
+
+        doReturn(1)
+            .when(this.secretBox)
+            .cryptoBoxAfternm(
+                any(byte[].class), any(byte[].class), anyInt(), any(byte[].class), eq(sharedKey.getKeyBytes())
+            );
+
+        final byte[] result = this.jnacl.sealAfterPrecomputation(message, nonce, sharedKey);
+
+        assertThat(result).isNotEmpty();
+
+        verify(this.secretBox)
+            .cryptoBoxAfternm(any(byte[].class), any(byte[].class), anyInt(), any(byte[].class), any(byte[].class));
+    }
+
+    @Test
+    public void openUsingSharedKeySodiumReturnsSuccess() {
+
+        final byte[] data = new byte[100];
+
+        doReturn(1)
+            .when(this.secretBox)
+            .cryptoBoxOpenAfternm(
+                any(byte[].class), eq(data), anyInt(), any(byte[].class), eq(sharedKey.getKeyBytes())
+            );
+
+        final byte[] results = this.jnacl.openAfterPrecomputation(data, nonce, sharedKey);
+
+        assertThat(results).isNotEmpty();
+
+        verify(this.secretBox).cryptoBoxOpenAfternm(
+            any(byte[].class), any(byte[].class), anyInt(), any(byte[].class), any(byte[].class)
+        );
+    }
+
+    @Test
+    public void openUsingKeysSodiumReturnsSucesss() {
+
+        final byte[] data = new byte[100];
+
+        final byte[] result = this.jnacl.open(data, nonce, publicKey, privateKey);
+
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    public void sealUsingKeysSodiumReturnsSuccess() {
+
+        final byte[] results = this.jnacl.seal(message, nonce, publicKey, privateKey);
+
+        assertThat(results).isNotEmpty();
+
+    }
+
+    @Test
+    public void generatingRandomKeyReturnsCorrectSize() {
+        final int expectedKeysize = 32;
+
+        final Key key = this.jnacl.createSingleKey();
+
+        assertThat(key.getKeyBytes()).hasSize(expectedKeysize);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <module>service-locator-spring</module>
         <module>nexus-encryption</module>
         <module>nexus-encryption-kalium</module>
+        <module>nexus-encryption-jnacl</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
This can be used as an alternative to Kalium.

Although JNaCL has no need for native bindings (unlike Kalium), it
likely has poorer performance.

Benchmarking needs to be performed to see how much quicker one is
over the other.