### PR TITLE
Move hardcoded config from KeyManager

### DIFF
--- a/nexus-app/src/main/java/com/github/nexus/enclave/keys/KeyManagerImpl.java
+++ b/nexus-app/src/main/java/com/github/nexus/enclave/keys/KeyManagerImpl.java
@@ -60,10 +60,10 @@ public class KeyManagerImpl implements KeyManager {
 
     }
 
-    public KeyManagerImpl(final String baseKeygenPath, final NaclFacade nacl, final Configuration configuration) {
+    public KeyManagerImpl(final NaclFacade nacl, final Configuration configuration) {
 
         this(
-            baseKeygenPath,
+            configuration.keygenBasePath(),
             nacl,
             configuration.publicKeys().stream().map(Paths::get).collect(toList()),
             configuration.privateKeys().stream().map(Paths::get).collect(toList())

--- a/nexus-app/src/main/resources/application-default.properties
+++ b/nexus-app/src/main/resources/application-default.properties
@@ -5,3 +5,5 @@ port=8080
 url=http://localhost
 
 othernodes=
+
+keygenBasePath=./

--- a/nexus-app/src/main/resources/nexus-spring.xml
+++ b/nexus-app/src/main/resources/nexus-spring.xml
@@ -55,7 +55,6 @@
     </bean>
 
     <bean name="keyManager" class="com.github.nexus.enclave.keys.KeyManagerImpl">
-        <constructor-arg value="./" />
         <constructor-arg ref="nacl" />
         <constructor-arg ref="config" />
     </bean>

--- a/nexus-app/src/test/java/com/github/nexus/TestConfiguration.java
+++ b/nexus-app/src/test/java/com/github/nexus/TestConfiguration.java
@@ -32,4 +32,9 @@ public class TestConfiguration implements Configuration {
         return Collections.emptyList();
     }
 
+    @Override
+    public String keygenBasePath() {
+        return "./";
+    }
+
 }

--- a/nexus-app/src/test/java/com/github/nexus/enclave/keys/KeyManagerTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/enclave/keys/KeyManagerTest.java
@@ -62,6 +62,7 @@ public class KeyManagerTest {
         Files.write(keygenPath.resolve("key.key"), privateKeyJson, StandardOpenOption.CREATE_NEW);
 
         final Configuration configuration = new TestConfiguration(){
+
             @Override
             public List<String> publicKeys() {
                 return singletonList(keygenPath.resolve("key.pub").toString());
@@ -71,17 +72,23 @@ public class KeyManagerTest {
             public List<String> privateKeys() {
                 return singletonList(keygenPath.resolve("key.key").toString());
             }
+
+            @Override
+            public String keygenBasePath() {
+                return keygenPath.toString();
+            }
+
         };
 
         this.naclFacade = mock(NaclFacade.class);
 
-        this.keyManager = new KeyManagerImpl(keygenPath.toString(), naclFacade, configuration);
+        this.keyManager = new KeyManagerImpl(naclFacade, configuration);
     }
 
     @Test
     public void initialisedWithNoKeys() {
 
-        this.keyManager = new KeyManagerImpl(keygenPath.toString(), naclFacade, new TestConfiguration());
+        this.keyManager = new KeyManagerImpl(naclFacade, new TestConfiguration());
 
         assertThat(keyManager).extracting("ourKeys").containsExactly(emptySet());
     }

--- a/nexus-configurator/src/main/java/com/github/nexus/configuration/Configuration.java
+++ b/nexus-configurator/src/main/java/com/github/nexus/configuration/Configuration.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 public interface Configuration {
 
+    String keygenBasePath();
+
     List<String> publicKeys();
 
     List<String> privateKeys();

--- a/nexus-configurator/src/main/java/com/github/nexus/configuration/ConfigurationFactory.java
+++ b/nexus-configurator/src/main/java/com/github/nexus/configuration/ConfigurationFactory.java
@@ -37,7 +37,7 @@ public class ConfigurationFactory {
     private static final String CONFIG_FILE_PROPERTY = "configfile";
 
     private static final String[] KNOWN_PROPERTIES = new String[] {
-        "publicKeys", "privateKeys", "port", "url", "othernodes"
+        "publicKeys", "privateKeys", "port", "url", "othernodes", "keygenBasePath"
     };
 
     private static Options options = new Options(){{
@@ -47,6 +47,7 @@ public class ConfigurationFactory {
         addOption("url", "url", true, "base url to use");
         addOption("port", "port", true, "port to listen for http requests on");
         addOption("othernodes", "othernodes", true, "initial set of other nodes");
+        addOption("keygenBasePath", "keygenBasePath", true, "base path that generated keys should be placed");
     }};
 
     private ConfigurationInterceptor[] interceptors = new ConfigurationInterceptor[]{

--- a/nexus-configurator/src/test/resources/application-default.properties
+++ b/nexus-configurator/src/test/resources/application-default.properties
@@ -4,3 +4,5 @@ privateKeys=10,20
 url=localhost
 port=8080
 othernodes=
+
+keygenBasePath=./


### PR DESCRIPTION
Make the base path for generated keys be a configuration property instead of a hardcoded parameter in the Spring context