### PR TITLE
Move the key management outside the enclave package

### DIFF
--- a/nexus-app/src/main/java/com/github/nexus/keys/KeyManager.java
+++ b/nexus-app/src/main/java/com/github/nexus/keys/KeyManager.java
@@ -1,4 +1,4 @@
-package com.github.nexus.enclave.keys;
+package com.github.nexus.keys;
 
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.KeyPair;

--- a/nexus-app/src/main/java/com/github/nexus/keys/KeyManagerImpl.java
+++ b/nexus-app/src/main/java/com/github/nexus/keys/KeyManagerImpl.java
@@ -1,4 +1,4 @@
-package com.github.nexus.enclave.keys;
+package com.github.nexus.keys;
 
 import com.github.nexus.configuration.Configuration;
 import com.github.nexus.nacl.Key;

--- a/nexus-app/src/main/java/com/github/nexus/node/PartyInfoServiceImpl.java
+++ b/nexus-app/src/main/java/com/github/nexus/node/PartyInfoServiceImpl.java
@@ -2,7 +2,7 @@ package com.github.nexus.node;
 
 
 import com.github.nexus.configuration.Configuration;
-import com.github.nexus.enclave.keys.KeyManager;
+import com.github.nexus.keys.KeyManager;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.node.model.Party;
 import com.github.nexus.node.model.PartyInfo;

--- a/nexus-app/src/main/java/com/github/nexus/transaction/TransactionServiceImpl.java
+++ b/nexus-app/src/main/java/com/github/nexus/transaction/TransactionServiceImpl.java
@@ -1,6 +1,6 @@
 package com.github.nexus.transaction;
 
-import com.github.nexus.enclave.keys.KeyManager;
+import com.github.nexus.keys.KeyManager;
 import com.github.nexus.enclave.model.MessageHash;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.NaclFacade;

--- a/nexus-app/src/main/resources/nexus-spring.xml
+++ b/nexus-app/src/main/resources/nexus-spring.xml
@@ -85,7 +85,7 @@
         <constructor-arg ref="nacl" />
     </bean>
 
-    <bean name="keyManager" class="com.github.nexus.enclave.keys.KeyManagerImpl">
+    <bean name="keyManager" class="com.github.nexus.keys.KeyManagerImpl">
         <constructor-arg ref="nacl" />
         <constructor-arg ref="config" />
     </bean>

--- a/nexus-app/src/test/java/com/github/nexus/keys/KeyManagerTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/keys/KeyManagerTest.java
@@ -1,7 +1,9 @@
-package com.github.nexus.enclave.keys;
+package com.github.nexus.keys;
 
 import com.github.nexus.TestConfiguration;
 import com.github.nexus.configuration.Configuration;
+import com.github.nexus.keys.KeyManager;
+import com.github.nexus.keys.KeyManagerImpl;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.KeyPair;
 import com.github.nexus.nacl.NaclFacade;

--- a/nexus-app/src/test/java/com/github/nexus/node/PartyInfoServiceTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/node/PartyInfoServiceTest.java
@@ -2,7 +2,7 @@ package com.github.nexus.node;
 
 import com.github.nexus.TestConfiguration;
 import com.github.nexus.configuration.Configuration;
-import com.github.nexus.enclave.keys.KeyManager;
+import com.github.nexus.keys.KeyManager;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.node.model.Party;
 import com.github.nexus.node.model.PartyInfo;

--- a/nexus-app/src/test/java/com/github/nexus/transaction/TransactionServiceTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/transaction/TransactionServiceTest.java
@@ -1,6 +1,6 @@
 package com.github.nexus.transaction;
 
-import com.github.nexus.enclave.keys.KeyManager;
+import com.github.nexus.keys.KeyManager;
 import com.github.nexus.enclave.model.MessageHash;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.NaclException;


### PR DESCRIPTION
Key management is not only to be used by the Enclave, so it should not live as a component of the Enclave.