### PR TITLE
Change the configuration to return a path directly

### DIFF
--- a/nexus-app/src/main/java/com/github/nexus/keys/KeyGeneratorImpl.java
+++ b/nexus-app/src/main/java/com/github/nexus/keys/KeyGeneratorImpl.java
@@ -10,7 +10,6 @@ import javax.json.Json;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Base64;
 import java.util.Objects;
@@ -21,7 +20,7 @@ public class KeyGeneratorImpl implements KeyGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyGeneratorImpl.class);
 
-    private final String basePath;
+    private final Path basePath;
 
     private final NaclFacade nacl;
 
@@ -41,9 +40,8 @@ public class KeyGeneratorImpl implements KeyGenerator {
         final String publicKeyBase64 = Base64.getEncoder().encodeToString(generated.getPublicKey().getKeyBytes());
         final String privateKeyBase64 = Base64.getEncoder().encodeToString(generated.getPrivateKey().getKeyBytes());
 
-        final Path workingDirectory = Paths.get(basePath).toAbsolutePath();
-        final Path publicKeyPath = workingDirectory.resolve(name + ".pub");
-        final Path privateKeyPath = workingDirectory.resolve(name + ".key");
+        final Path publicKeyPath = basePath.resolve(name + ".pub");
+        final Path privateKeyPath = basePath.resolve(name + ".key");
 
         final byte[] privateKeyJson = Json.createObjectBuilder()
             .add("type", "unlocked")

--- a/nexus-app/src/test/java/com/github/nexus/TestConfiguration.java
+++ b/nexus-app/src/test/java/com/github/nexus/TestConfiguration.java
@@ -2,6 +2,8 @@ package com.github.nexus;
 
 import com.github.nexus.configuration.Configuration;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,8 +35,8 @@ public class TestConfiguration implements Configuration {
     }
 
     @Override
-    public String keygenBasePath() {
-        return "./";
+    public Path keygenBasePath() {
+        return Paths.get("./").toAbsolutePath();
     }
 
 }

--- a/nexus-app/src/test/java/com/github/nexus/keys/KeyGeneratorTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/keys/KeyGeneratorTest.java
@@ -52,8 +52,8 @@ public class KeyGeneratorTest {
         final Configuration configuration = new TestConfiguration(){
 
             @Override
-            public String keygenBasePath() {
-                return keygenPath.toString();
+            public Path keygenBasePath() {
+                return keygenPath;
             }
 
         };

--- a/nexus-configurator/src/main/java/com/github/nexus/configuration/Configuration.java
+++ b/nexus-configurator/src/main/java/com/github/nexus/configuration/Configuration.java
@@ -1,10 +1,11 @@
 package com.github.nexus.configuration;
 
+import java.nio.file.Path;
 import java.util.List;
 
 public interface Configuration {
 
-    String keygenBasePath();
+    Path keygenBasePath();
 
     List<String> publicKeys();
 

--- a/nexus-configurator/src/main/java/com/github/nexus/configuration/ConfigurationImpl.java
+++ b/nexus-configurator/src/main/java/com/github/nexus/configuration/ConfigurationImpl.java
@@ -1,5 +1,7 @@
 package com.github.nexus.configuration;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -14,8 +16,8 @@ public class ConfigurationImpl implements Configuration {
     }
 
     @Override
-    public String keygenBasePath() {
-        return properties.getProperty("keygenBasePath");
+    public Path keygenBasePath() {
+        return Paths.get(properties.getProperty("keygenBasePath")).toAbsolutePath();
     }
 
     @Override

--- a/nexus-configurator/src/test/java/com/github/nexus/configuration/ConfigImplTest.java
+++ b/nexus-configurator/src/test/java/com/github/nexus/configuration/ConfigImplTest.java
@@ -2,6 +2,7 @@ package com.github.nexus.configuration;
 
 import org.junit.Test;
 
+import java.nio.file.Paths;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,7 +23,7 @@ public class ConfigImplTest {
 
         final Configuration configuration = new ConfigurationImpl(configProperties);
 
-        assertThat(configuration.keygenBasePath()).isEqualTo("basepath");
+        assertThat(configuration.keygenBasePath()).isEqualTo(Paths.get("basepath").toAbsolutePath());
         assertThat(configuration.publicKeys()).hasSize(3).containsExactly("key1", "key2", "key3");
         assertThat(configuration.privateKeys()).isEqualTo("priv1,priv2");
         assertThat(configuration.url()).isEqualTo("http://url.com");


### PR DESCRIPTION
Where the configuration represents a path, return a path object instead of the string representation.
No validation is performed on the path (e.g. checking it exists).