### PR TITLE
Fix /sendRaw issues

### DIFF
--- a/nexus-app/src/main/java/com/github/nexus/api/TransactionResource.java
+++ b/nexus-app/src/main/java/com/github/nexus/api/TransactionResource.java
@@ -26,9 +26,9 @@ public class TransactionResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionResource.class);
 
     private final Enclave enclave;
-    
+
     private final Base64Decoder base64Decoder;
-    
+
     public TransactionResource(final Enclave enclave,final Base64Decoder base64Decoder) {
         this.enclave = requireNonNull(enclave, "enclave must not be null");
         this.base64Decoder = requireNonNull(base64Decoder, "decoder must not be null");
@@ -41,7 +41,7 @@ public class TransactionResource {
     public Response send(@Valid final SendRequest sendRequest) {
 
         byte[] from = base64Decoder.decode(sendRequest.getFrom());
-            
+
         byte[][] recipients =
             Stream.of(sendRequest.getTo())
                 .map(base64Decoder::decode)
@@ -65,20 +65,21 @@ public class TransactionResource {
     @Path("/sendraw")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @Produces(MediaType.TEXT_PLAIN)
-    public Response sendRaw(@Context final HttpHeaders headers, byte[] b64Payload) {
+    public Response sendRaw(@Context final HttpHeaders headers, byte[] payload) {
 
-        byte[] from = base64Decoder.decode(headers.getHeaderString("c11n-from"));
+        final byte[] from = base64Decoder.decode(headers.getHeaderString("c11n-from"));
 
-        byte[][] recipients = headers.getRequestHeader("c11n-from")
-            .stream().map(base64Decoder::decode).toArray(byte[][]::new);
+        final byte[][] recipients = headers.getRequestHeader("c11n-to")
+            .stream()
+            .map(base64Decoder::decode)
+            .toArray(byte[][]::new);
 
-        byte[] payload = base64Decoder.decode(new String(b64Payload));
+        final byte[] key = enclave.store(from, recipients, payload).getHashBytes();
 
-        byte[] key = enclave.store(from, recipients, payload).getHashBytes();
+        final String encodedKey = base64Decoder.encodeToString(key);
 
-        String encodedKey = base64Decoder.encodeToString(key);
-
-        return Response.status(Response.Status.CREATED)
+        //TODO: Quorum expects only 200 responses. When Quorum can handle a 201, change to CREATED
+        return Response.status(Response.Status.OK)
             .entity(encodedKey)
             .build();
     }

--- a/nexus-app/src/test/java/com/github/nexus/api/TransactionResourceTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/api/TransactionResourceTest.java
@@ -10,31 +10,27 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.util.Base64;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class TransactionResourceTest {
 
-    @Mock
     private Enclave enclave;
+
+    private Base64Decoder base64Decoder = Base64Decoder.create();
 
     private TransactionResource transactionResource;
 
-    private Base64Decoder base64Decoder = Base64Decoder.create();
-    
     @Before
     public void onSetup() {
-        MockitoAnnotations.initMocks(this);
-        transactionResource = new TransactionResource(enclave,base64Decoder);
+        this.enclave = mock(Enclave.class);
+        transactionResource = new TransactionResource(enclave, base64Decoder);
     }
 
     @After
@@ -62,23 +58,21 @@ public class TransactionResourceTest {
     }
 
     @Test
-    public void testSendRaw(){
-        HttpHeaders headers = mock(HttpHeaders.class);
+    public void testSendRaw() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        final byte[] payload = "Zm9v".getBytes();
 
-        when(headers.getHeaderString("c11n-from"))
-            .thenReturn("bXlwdWJsaWNrZXk=");
+        doReturn("bXlwdWJsaWNrZXk=").when(headers).getHeaderString("c11n-from");
+        doReturn(singletonList("cmVjaXBpZW50MQ==")).when(headers).getRequestHeader("c11n-to");
 
-        when(headers.getRequestHeader("c11n-to"))
-            .thenReturn(Stream.of("cmVjaXBpZW50MQ==")
-                .collect(Collectors.toList()));
+        doReturn(new MessageHash("SOMEKEY".getBytes())).when(enclave).store(any(), any(), eq(payload));
 
-        when(enclave.store(any(), any(), any())).thenReturn(new MessageHash("SOMEKEY".getBytes()));
+        final Response response = transactionResource.sendRaw(headers, payload);
 
-        Response response = transactionResource.sendRaw(headers, "Zm9v".getBytes());
+        verify(enclave).store(any(byte[].class), any(byte[][].class), eq(payload));
 
-        verify(enclave, times(1)).store(any(), any(), any());
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(201);
+        assertThat(response.getStatus()).isEqualTo(200);
     }
 
 
@@ -119,12 +113,12 @@ public class TransactionResourceTest {
         ReceiveResponse receiveResponse = (ReceiveResponse) response.getEntity();
 
         assertThat(receiveResponse.getPayload()).isEqualTo("U09NRSBEQVRB");
-        verify(enclave).receive(any(),any());
+        verify(enclave).receive(any(), any());
         assertThat(response.getStatus()).isEqualTo(201);
     }
 
     @Test
-    public void testReceiveRaw(){
+    public void testReceiveRaw() {
         HttpHeaders headers = mock(HttpHeaders.class);
 
         when(headers.getHeaderString("c11n-key"))
@@ -143,7 +137,7 @@ public class TransactionResourceTest {
     }
 
     @Test(expected = DecodingException.class)
-    public void testReceiveThrowDecodingException(){
+    public void testReceiveThrowDecodingException() {
         ReceiveRequest receiveRequest = new ReceiveRequest();
         receiveRequest.setKey("ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc=");
         receiveRequest.setTo("1");

--- a/nexus-test/src/test/java/com/github/nexus/test/NexusIT.java
+++ b/nexus-test/src/test/java/com/github/nexus/test/NexusIT.java
@@ -1,29 +1,22 @@
 package com.github.nexus.test;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import javax.json.Json;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.StringReader;
-import java.net.URI;
-import java.util.Base64;
-import javax.json.JsonObject;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.UriBuilder;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.*;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
+import java.io.*;
+import java.net.URI;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class NexusIT {
 
@@ -186,7 +179,7 @@ public class NexusIT {
     }
 
     @Test
-    public void requestOpenApiSchemaDocument() throws IOException {
+    public void requestOpenApiSchemaDocument() {
 
         javax.ws.rs.core.Response response = client
                 .target(SERVER_URI)
@@ -205,7 +198,7 @@ public class NexusIT {
     }
 
     @Test
-    public void sendraw() throws Exception {
+    public void sendraw() {
 
         javax.ws.rs.core.Response response = client.target(SERVER_URI)
                 .path("/sendraw")
@@ -215,13 +208,13 @@ public class NexusIT {
                 .post(Entity.entity("Zm9v", MediaType.APPLICATION_OCTET_STREAM));
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(201);
+        assertThat(response.getStatus()).isEqualTo(200);
     }
 
 
     @Ignore
     @Test
-    public void receiveraw() throws Exception {
+    public void receiveraw() {
 
         String key = Base64.getEncoder().encodeToString("<replace the hashkey here>".getBytes());
         String recipient =  Base64.getEncoder().encodeToString("yGcjkFyZklTTXrn8+WIkYwicA2EGBn9wZFkctAad4X0=".getBytes());


### PR DESCRIPTION
Use correct header name to get recipients
Don't decode the payload from Base64
Return a 200 OK back to Quorum