### PR TITLE
Decouple server from socket connections

### DIFF
--- a/nexus-socket/src/main/java/com/github/nexus/socket/UnixDomainServerSocket.java
+++ b/nexus-socket/src/main/java/com/github/nexus/socket/UnixDomainServerSocket.java
@@ -1,6 +1,5 @@
 package com.github.nexus.socket;
 
-import com.github.nexus.junixsocket.adapter.UnixSocketFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,7 +8,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.nio.file.Path;
 import java.util.Objects;
 
 /**
@@ -24,25 +22,8 @@ public class UnixDomainServerSocket {
 
     private Socket socket;
 
-    private final UnixSocketFactory unixSocketFactory;
-
-    public UnixDomainServerSocket(final UnixSocketFactory unixSocketFactory) {
-        this.unixSocketFactory = Objects.requireNonNull(unixSocketFactory);
-    }
-
-    /**
-     * Create a unix domain socket, using the specified directory + path.
-     */
-    public void create(final Path socketFile) {
-
-        try {
-            server = unixSocketFactory.createServerSocket(socketFile);
-            LOGGER.info("server: {}", server);
-
-        } catch (IOException ex) {
-            LOGGER.error("Failed to create Unix Domain Socket: {}/{}", socketFile.toString());
-            throw new NexusSocketException(ex);
-        }
+    public UnixDomainServerSocket(final ServerSocket server) {
+        this.server = Objects.requireNonNull(server);
     }
 
     /**

--- a/nexus-socket/src/test/java/com/github/nexus/socket/UnixDomainServerSocketTest.java
+++ b/nexus-socket/src/test/java/com/github/nexus/socket/UnixDomainServerSocketTest.java
@@ -1,6 +1,224 @@
+//package com.github.nexus.socket;
+//
+//import com.github.nexus.junixsocket.adapter.UnixSocketFactory;
+//import org.junit.After;
+//import org.junit.Before;
+//import org.junit.Test;
+//
+//import java.io.ByteArrayInputStream;
+//import java.io.ByteArrayOutputStream;
+//import java.io.IOException;
+//import java.net.ServerSocket;
+//import java.net.Socket;
+//import java.nio.file.Files;
+//import java.nio.file.Path;
+//import java.nio.file.Paths;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.catchThrowable;
+//import static org.mockito.Mockito.*;
+//
+//public class UnixDomainServerSocketTest {
+//
+//    private Path socketFile = Paths.get(System.getProperty("java.io.tempdir"), "junit.txt");
+//
+//    private UnixSocketFactory mockUnixSocketFactory;
+//
+//    private UnixDomainServerSocket unixDomainServerSocket;
+//
+//    @Before
+//    public void setUp() {
+//        mockUnixSocketFactory = mock(UnixSocketFactory.class);
+//        unixDomainServerSocket = new UnixDomainServerSocket(mockUnixSocketFactory);
+//    }
+//
+//    @After
+//    public void tearDown() throws IOException {
+//        verifyNoMoreInteractions(mockUnixSocketFactory);
+//        Files.deleteIfExists(socketFile);
+//    }
+//
+//    @Test
+//    public void testServerCreate() throws IOException {
+//        final String path = "/tmp";
+//        final String filename = "tst1.ipc";
+//        final Path socketPath = Paths.get(path, filename);
+//
+//        unixDomainServerSocket.create(socketPath);
+//
+//        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//
+//    }
+//
+//    @Test
+//    public void testServerCreateThrowsIOException() throws Exception {
+//
+//        final String path = "/tmp";
+//        final String filename = "tst1.ipc";
+//
+//        IOException exception = new IOException("BANG!!");
+//        final Path socketPath = Paths.get(path, filename);
+//
+//        doThrow(exception).when(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//
+//        final Throwable ex = catchThrowable(() -> unixDomainServerSocket.create(socketPath));
+//        assertThat(ex)
+//            .isInstanceOf(NexusSocketException.class)
+//            .hasMessageContaining("BANG!!")
+//            .hasCauseExactlyInstanceOf(IOException.class);
+//
+//        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//    }
+//
+//    @Test
+//    public void connect() throws IOException {
+//        ServerSocket serverSocket = mock(ServerSocket.class);
+//
+//        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
+//
+//        unixDomainServerSocket.create(socketFile);
+//
+//        unixDomainServerSocket.connect();
+//
+//        verify(serverSocket).accept();
+//        verifyNoMoreInteractions(serverSocket);
+//        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//    }
+//
+//    @Test
+//    public void connectThrowsIOException() throws IOException {
+//        ServerSocket serverSocket = mock(ServerSocket.class);
+//
+//        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
+//
+//        unixDomainServerSocket.create(socketFile);
+//
+//        doThrow(IOException.class).when(serverSocket).accept();
+//
+//        final Throwable ex = catchThrowable(unixDomainServerSocket::connect);
+//        assertThat(ex).isInstanceOf(NexusSocketException.class).hasCauseExactlyInstanceOf(IOException.class);
+//
+//        verify(serverSocket).accept();
+//        verifyNoMoreInteractions(serverSocket);
+//        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//    }
+//
+//    @Test
+//    public void connectAndRead() throws IOException {
+//
+//        final String data = "HELLOW-99";
+//
+//        Socket mockSocket = mock(Socket.class);
+//
+//        ByteArrayInputStream inputStream = new ByteArrayInputStream(data.getBytes());
+//
+//        when(mockSocket.getInputStream()).thenReturn(inputStream);
+//
+//        ServerSocket serverSocket = mock(ServerSocket.class);
+//        when(serverSocket.accept()).thenReturn(mockSocket);
+//
+//        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
+//
+//        unixDomainServerSocket.create(socketFile);
+//
+//        unixDomainServerSocket.connect();
+//
+//        final byte[] result = unixDomainServerSocket.read();
+//
+//        //TODO: Verify that the right padding is correct behaviour
+//        assertThat(new String(result)).startsWith(data);
+//
+//        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//
+//        verify(serverSocket).accept();
+//        verify(mockSocket).getInputStream();
+//    }
+//
+//    @Test
+//    public void connectAndWrite() throws IOException {
+//
+//        final String data = "HELLOW-99";
+//
+//        Socket mockSocket = mock(Socket.class);
+//
+//        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+//
+//        when(mockSocket.getOutputStream()).thenReturn(outputStream);
+//
+//        ServerSocket serverSocket = mock(ServerSocket.class);
+//        when(serverSocket.accept()).thenReturn(mockSocket);
+//
+//        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
+//
+//        unixDomainServerSocket.create(socketFile);
+//
+//        unixDomainServerSocket.connect();
+//
+//        unixDomainServerSocket.write(data.getBytes());
+//
+//        assertThat(data).isEqualTo(new String(outputStream.toByteArray()));
+//
+//        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//
+//        verify(serverSocket).accept();
+//        verify(mockSocket).getOutputStream();
+//        verifyNoMoreInteractions(serverSocket, mockSocket);
+//    }
+//
+//    @Test
+//    public void connectAndReadThrowsException() throws IOException {
+//
+//        Socket mockSocket = mock(Socket.class);
+//
+//        doThrow(IOException.class).when(mockSocket).getInputStream();
+//
+//        ServerSocket serverSocket = mock(ServerSocket.class);
+//        when(serverSocket.accept()).thenReturn(mockSocket);
+//
+//        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
+//
+//        unixDomainServerSocket.create(socketFile);
+//        unixDomainServerSocket.connect();
+//
+//        final Throwable ex = catchThrowable(unixDomainServerSocket::read);
+//        assertThat(ex).isInstanceOf(NexusSocketException.class).hasCauseExactlyInstanceOf(IOException.class);
+//
+//
+//        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//
+//        verify(serverSocket).accept();
+//        verify(mockSocket).getInputStream();
+//        verifyNoMoreInteractions(serverSocket, mockSocket);
+//    }
+//
+//    @Test
+//    public void connectAndWriteThrowsException() throws IOException {
+//
+//        Socket mockSocket = mock(Socket.class);
+//
+//        doThrow(IOException.class).when(mockSocket).getOutputStream();
+//
+//        ServerSocket serverSocket = mock(ServerSocket.class);
+//        when(serverSocket.accept()).thenReturn(mockSocket);
+//
+//        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
+//
+//        unixDomainServerSocket.create(socketFile);
+//        unixDomainServerSocket.connect();
+//
+//        final Throwable ex = catchThrowable(() -> unixDomainServerSocket.write("HELLOW".getBytes()));
+//        assertThat(ex).isInstanceOf(NexusSocketException.class).hasCauseExactlyInstanceOf(IOException.class);
+//
+//
+//        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
+//        verify(serverSocket).accept();
+//        verify(mockSocket).getOutputStream();
+//        verifyNoMoreInteractions(serverSocket, mockSocket);
+//    }
+//}
+
 package com.github.nexus.socket;
 
-import com.github.nexus.junixsocket.adapter.UnixSocketFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,77 +240,32 @@ public class UnixDomainServerSocketTest {
 
     private Path socketFile = Paths.get(System.getProperty("java.io.tempdir"), "junit.txt");
 
-    private UnixSocketFactory mockUnixSocketFactory;
+    private ServerSocket serverSocket;
 
     private UnixDomainServerSocket unixDomainServerSocket;
 
     @Before
     public void setUp() {
-        mockUnixSocketFactory = mock(UnixSocketFactory.class);
-        unixDomainServerSocket = new UnixDomainServerSocket(mockUnixSocketFactory);
+        serverSocket = mock(ServerSocket.class);
+        unixDomainServerSocket = new UnixDomainServerSocket(serverSocket);
     }
 
     @After
     public void tearDown() throws IOException {
-        verifyNoMoreInteractions(mockUnixSocketFactory);
+        verifyNoMoreInteractions(serverSocket);
         Files.deleteIfExists(socketFile);
     }
 
     @Test
-    public void testServerCreate() throws IOException {
-        final String path = "/tmp";
-        final String filename = "tst1.ipc";
-        final Path socketPath = Paths.get(path, filename);
-
-        unixDomainServerSocket.create(socketPath);
-
-        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
-
-    }
-
-    @Test
-    public void testServerCreateThrowsIOException() throws Exception {
-
-        final String path = "/tmp";
-        final String filename = "tst1.ipc";
-
-        IOException exception = new IOException("BANG!!");
-        final Path socketPath = Paths.get(path, filename);
-
-        doThrow(exception).when(mockUnixSocketFactory).createServerSocket(any(Path.class));
-
-        final Throwable ex = catchThrowable(() -> unixDomainServerSocket.create(socketPath));
-        assertThat(ex)
-            .isInstanceOf(NexusSocketException.class)
-            .hasMessageContaining("BANG!!")
-            .hasCauseExactlyInstanceOf(IOException.class);
-
-        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
-    }
-
-    @Test
     public void connect() throws IOException {
-        ServerSocket serverSocket = mock(ServerSocket.class);
-
-        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
-
-        unixDomainServerSocket.create(socketFile);
-
         unixDomainServerSocket.connect();
 
         verify(serverSocket).accept();
         verifyNoMoreInteractions(serverSocket);
-        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
     }
 
     @Test
     public void connectThrowsIOException() throws IOException {
-        ServerSocket serverSocket = mock(ServerSocket.class);
-
-        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
-
-        unixDomainServerSocket.create(socketFile);
-
         doThrow(IOException.class).when(serverSocket).accept();
 
         final Throwable ex = catchThrowable(unixDomainServerSocket::connect);
@@ -100,7 +273,6 @@ public class UnixDomainServerSocketTest {
 
         verify(serverSocket).accept();
         verifyNoMoreInteractions(serverSocket);
-        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
     }
 
     @Test
@@ -108,18 +280,13 @@ public class UnixDomainServerSocketTest {
 
         final String data = "HELLOW-99";
 
-        Socket mockSocket = mock(Socket.class);
+        final Socket mockSocket = mock(Socket.class);
 
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(data.getBytes());
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(data.getBytes());
 
-        when(mockSocket.getInputStream()).thenReturn(inputStream);
+        doReturn(inputStream).when(mockSocket).getInputStream();
 
-        ServerSocket serverSocket = mock(ServerSocket.class);
-        when(serverSocket.accept()).thenReturn(mockSocket);
-
-        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
-
-        unixDomainServerSocket.create(socketFile);
+        doReturn(mockSocket).when(serverSocket).accept();
 
         unixDomainServerSocket.connect();
 
@@ -127,8 +294,6 @@ public class UnixDomainServerSocketTest {
 
         //TODO: Verify that the right padding is correct behaviour
         assertThat(new String(result)).startsWith(data);
-
-        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
 
         verify(serverSocket).accept();
         verify(mockSocket).getInputStream();
@@ -139,26 +304,19 @@ public class UnixDomainServerSocketTest {
 
         final String data = "HELLOW-99";
 
-        Socket mockSocket = mock(Socket.class);
+        final Socket mockSocket = mock(Socket.class);
 
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        when(mockSocket.getOutputStream()).thenReturn(outputStream);
+        doReturn(outputStream).when(mockSocket).getOutputStream();
 
-        ServerSocket serverSocket = mock(ServerSocket.class);
-        when(serverSocket.accept()).thenReturn(mockSocket);
-
-        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
-
-        unixDomainServerSocket.create(socketFile);
+        doReturn(mockSocket).when(serverSocket).accept();
 
         unixDomainServerSocket.connect();
 
         unixDomainServerSocket.write(data.getBytes());
 
         assertThat(data).isEqualTo(new String(outputStream.toByteArray()));
-
-        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
 
         verify(serverSocket).accept();
         verify(mockSocket).getOutputStream();
@@ -172,19 +330,12 @@ public class UnixDomainServerSocketTest {
 
         doThrow(IOException.class).when(mockSocket).getInputStream();
 
-        ServerSocket serverSocket = mock(ServerSocket.class);
         when(serverSocket.accept()).thenReturn(mockSocket);
 
-        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
-
-        unixDomainServerSocket.create(socketFile);
         unixDomainServerSocket.connect();
 
         final Throwable ex = catchThrowable(unixDomainServerSocket::read);
         assertThat(ex).isInstanceOf(NexusSocketException.class).hasCauseExactlyInstanceOf(IOException.class);
-
-
-        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
 
         verify(serverSocket).accept();
         verify(mockSocket).getInputStream();
@@ -198,19 +349,14 @@ public class UnixDomainServerSocketTest {
 
         doThrow(IOException.class).when(mockSocket).getOutputStream();
 
-        ServerSocket serverSocket = mock(ServerSocket.class);
         when(serverSocket.accept()).thenReturn(mockSocket);
 
-        when(mockUnixSocketFactory.createServerSocket(any(Path.class))).thenReturn(serverSocket);
-
-        unixDomainServerSocket.create(socketFile);
         unixDomainServerSocket.connect();
 
         final Throwable ex = catchThrowable(() -> unixDomainServerSocket.write("HELLOW".getBytes()));
         assertThat(ex).isInstanceOf(NexusSocketException.class).hasCauseExactlyInstanceOf(IOException.class);
 
 
-        verify(mockUnixSocketFactory).createServerSocket(any(Path.class));
         verify(serverSocket).accept();
         verify(mockSocket).getOutputStream();
         verifyNoMoreInteractions(serverSocket, mockSocket);

--- a/nexus-socket/src/test/java/com/github/nexus/socket/UnixDomainSocketIT.java
+++ b/nexus-socket/src/test/java/com/github/nexus/socket/UnixDomainSocketIT.java
@@ -3,6 +3,8 @@ package com.github.nexus.socket;
 import com.github.nexus.junixsocket.adapter.UnixSocketFactory;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,7 +18,7 @@ public class UnixDomainSocketIT {
     private UnixSocketFactory unixSocketFactory = UnixSocketFactory.create();
 
     @Test
-    public void sendMessageToClient() {
+    public void sendMessageToClient() throws IOException {
 
         //Create a server which is listening on the socket
         TestSocketServer server = new TestSocketServer();
@@ -41,9 +43,10 @@ public class UnixDomainSocketIT {
 
         UnixDomainServerSocket serverUds;
 
-        TestSocketServer() {
-            serverUds = new UnixDomainServerSocket(unixSocketFactory);
-            serverUds.create(Paths.get("/tmp", "tst2.ipc"));
+        TestSocketServer() throws IOException {
+            final ServerSocket serverSocket = unixSocketFactory.createServerSocket(Paths.get("/tmp", "tst2.ipc"));
+
+            serverUds = new UnixDomainServerSocket(serverSocket);
         }
 
         public void run() {


### PR DESCRIPTION
Move creation of the server into the SocketServer class, so that the UnixDomainSocketServer is only concerned with creating Socket connections.