### PR TITLE
Split private key un/enc from generation

### DIFF
--- a/key-encryption/pom.xml
+++ b/key-encryption/pom.xml
@@ -5,9 +5,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>nexus-keygen</artifactId>
-
-    <name>nexus-keygen</name>
+    <artifactId>key-encryption</artifactId>
     <packaging>jar</packaging>
 
     <parent>
@@ -42,12 +40,6 @@
             <groupId>com.github.nexus</groupId>
             <artifactId>nexus-encryption-jnacl</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.nexus</groupId>
-            <artifactId>key-encryption</artifactId>
-            <version>1.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/key-encryption/src/main/java/com/github/nexus/keyenc/EncryptedPrivateKey.java
+++ b/key-encryption/src/main/java/com/github/nexus/keyenc/EncryptedPrivateKey.java
@@ -1,4 +1,4 @@
-package com.github.nexus.keygen;
+package com.github.nexus.keyenc;
 
 import com.github.nexus.argon2.ArgonOptions;
 

--- a/key-encryption/src/main/java/com/github/nexus/keyenc/KeyEncryptor.java
+++ b/key-encryption/src/main/java/com/github/nexus/keyenc/KeyEncryptor.java
@@ -1,4 +1,4 @@
-package com.github.nexus.keygen;
+package com.github.nexus.keyenc;
 
 import com.github.nexus.nacl.Key;
 

--- a/key-encryption/src/main/java/com/github/nexus/keyenc/KeyEncryptorFactory.java
+++ b/key-encryption/src/main/java/com/github/nexus/keyenc/KeyEncryptorFactory.java
@@ -1,4 +1,4 @@
-package com.github.nexus.keygen;
+package com.github.nexus.keyenc;
 
 import com.github.nexus.argon2.Argon2;
 import com.github.nexus.nacl.NaclFacadeFactory;

--- a/key-encryption/src/main/java/com/github/nexus/keyenc/KeyEncryptorImpl.java
+++ b/key-encryption/src/main/java/com/github/nexus/keyenc/KeyEncryptorImpl.java
@@ -1,4 +1,4 @@
-package com.github.nexus.keygen;
+package com.github.nexus.keyenc;
 
 import com.github.nexus.argon2.Argon2;
 import com.github.nexus.argon2.ArgonResult;

--- a/key-encryption/src/test/java/com/github/nexus/keyenc/KeyEncryptorFactoryTest.java
+++ b/key-encryption/src/test/java/com/github/nexus/keyenc/KeyEncryptorFactoryTest.java
@@ -1,4 +1,4 @@
-package com.github.nexus.keygen;
+package com.github.nexus.keyenc;
 
 import org.junit.Test;
 

--- a/key-encryption/src/test/java/com/github/nexus/keyenc/KeyEncryptorIT.java
+++ b/key-encryption/src/test/java/com/github/nexus/keyenc/KeyEncryptorIT.java
@@ -1,16 +1,15 @@
-package com.github.nexus.keygen;
+package com.github.nexus.keyenc;
 
 import com.github.nexus.argon2.Argon2;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.NaclFacade;
 import com.github.nexus.nacl.NaclFacadeFactory;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.json.JsonObject;
 import java.util.Base64;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class KeyEncryptorIT {
 
@@ -40,7 +39,7 @@ public class KeyEncryptorIT {
 
         final Key decryptedKey = keyEncryptor.decryptPrivateKey(jsonObject, password);
 
-        assertThat(decryptedKey).isEqualTo(privateKey);
+        Assertions.assertThat(decryptedKey).isEqualTo(privateKey);
 
     }
 

--- a/key-encryption/src/test/java/com/github/nexus/keyenc/KeyEncryptorTest.java
+++ b/key-encryption/src/test/java/com/github/nexus/keyenc/KeyEncryptorTest.java
@@ -1,4 +1,4 @@
-package com.github.nexus.keygen;
+package com.github.nexus.keyenc;
 
 import com.github.nexus.argon2.Argon2;
 import com.github.nexus.argon2.ArgonOptions;
@@ -6,8 +6,10 @@ import com.github.nexus.argon2.ArgonResult;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.NaclFacade;
 import com.github.nexus.nacl.Nonce;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -45,22 +47,22 @@ public class KeyEncryptorTest {
         final String password = "pass";
         final ArgonResult result = new ArgonResult(new ArgonOptions("i", 1, 1, 1), new byte[]{}, new byte[]{});
 
-        doReturn(result).when(argon2).hash(eq(password), any(byte[].class));
-        doReturn(new Nonce(new byte[]{})).when(nacl).randomNonce();
+        Mockito.doReturn(result).when(argon2).hash(eq(password), any(byte[].class));
+        Mockito.doReturn(new Nonce(new byte[]{})).when(nacl).randomNonce();
         doReturn(new byte[]{}).when(nacl).sealAfterPrecomputation(any(byte[].class), any(Nonce.class), any(Key.class));
 
         final JsonObject returnJson = keyEncryptor.encryptPrivateKey(key, password);
 
         final JsonObject aopts = returnJson.getJsonObject("aopts");
 
-        assertThat(returnJson.getString("sbox")).isNotNull();
-        assertThat(returnJson.getString("asalt")).isNotNull();
-        assertThat(returnJson.getString("snonce")).isNotNull();
-        assertThat(aopts).isNotNull();
-        assertThat(aopts.getInt("memory")).isNotNull();
-        assertThat(aopts.getInt("parallelism")).isNotNull();
-        assertThat(aopts.getInt("iterations")).isNotNull();
-        assertThat(aopts.getString("variant")).isNotNull();
+        Assertions.assertThat(returnJson.getString("sbox")).isNotNull();
+        Assertions.assertThat(returnJson.getString("asalt")).isNotNull();
+        Assertions.assertThat(returnJson.getString("snonce")).isNotNull();
+        Assertions.assertThat(aopts).isNotNull();
+        Assertions.assertThat(aopts.getInt("memory")).isNotNull();
+        Assertions.assertThat(aopts.getInt("parallelism")).isNotNull();
+        Assertions.assertThat(aopts.getInt("iterations")).isNotNull();
+        Assertions.assertThat(aopts.getString("variant")).isNotNull();
 
         verify(argon2).hash(eq(password), any(byte[].class));
         verify(nacl).randomNonce();
@@ -90,13 +92,13 @@ public class KeyEncryptorTest {
             .when(nacl)
             .openAfterPrecomputation(any(byte[].class), any(Nonce.class), any(Key.class));
 
-        doReturn(new ArgonResult(null, new byte[]{}, new byte[]{4, 5, 6}))
+        Mockito.doReturn(new ArgonResult(null, new byte[]{}, new byte[]{4, 5, 6}))
             .when(argon2)
             .hash(any(ArgonOptions.class), eq(password), any(byte[].class));
 
         final Key key = keyEncryptor.decryptPrivateKey(parsed, password);
 
-        assertThat(key.getKeyBytes()).isEqualTo(new byte[]{1, 2, 3});
+        Assertions.assertThat(key.getKeyBytes()).isEqualTo(new byte[]{1, 2, 3});
 
         verify(nacl).openAfterPrecomputation(any(byte[].class), any(Nonce.class), any(Key.class));
         verify(argon2).hash(any(ArgonOptions.class), eq(password), any(byte[].class));

--- a/nexus-app/src/main/java/com/github/nexus/key/KeyManagerImpl.java
+++ b/nexus-app/src/main/java/com/github/nexus/key/KeyManagerImpl.java
@@ -3,7 +3,7 @@ package com.github.nexus.key;
 import com.github.nexus.configuration.Configuration;
 import com.github.nexus.configuration.model.KeyData;
 import com.github.nexus.key.exception.KeyNotFoundException;
-import com.github.nexus.keygen.KeyEncryptor;
+import com.github.nexus.keyenc.KeyEncryptor;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.KeyPair;
 import org.slf4j.Logger;

--- a/nexus-app/src/main/resources/nexus-spring.xml
+++ b/nexus-app/src/main/resources/nexus-spring.xml
@@ -94,7 +94,7 @@
 
     <bean name="argon2" class="com.github.nexus.argon2.Argon2" factory-method="create" />
 
-    <bean name="keyEncryptor" class="com.github.nexus.keygen.KeyEncryptorImpl" >
+    <bean name="keyEncryptor" class="com.github.nexus.keyenc.KeyEncryptorImpl" >
         <constructor-arg ref="argon2"/>
         <constructor-arg ref="nacl"/>
     </bean>

--- a/nexus-app/src/test/java/com/github/nexus/key/KeyManagerTest.java
+++ b/nexus-app/src/test/java/com/github/nexus/key/KeyManagerTest.java
@@ -3,7 +3,7 @@ package com.github.nexus.key;
 import com.github.nexus.TestConfiguration;
 import com.github.nexus.configuration.Configuration;
 import com.github.nexus.configuration.model.KeyData;
-import com.github.nexus.keygen.KeyEncryptor;
+import com.github.nexus.keyenc.KeyEncryptor;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.KeyPair;
 import org.junit.Before;

--- a/nexus-keygen/src/main/java/com/github/nexus/keygen/KeyGeneratorFactory.java
+++ b/nexus-keygen/src/main/java/com/github/nexus/keygen/KeyGeneratorFactory.java
@@ -1,6 +1,7 @@
 package com.github.nexus.keygen;
 
 import com.github.nexus.configuration.Configuration;
+import com.github.nexus.keyenc.KeyEncryptorFactory;
 import com.github.nexus.nacl.NaclFacadeFactory;
 
 public interface KeyGeneratorFactory {

--- a/nexus-keygen/src/main/java/com/github/nexus/keygen/KeyGeneratorImpl.java
+++ b/nexus-keygen/src/main/java/com/github/nexus/keygen/KeyGeneratorImpl.java
@@ -1,6 +1,7 @@
 package com.github.nexus.keygen;
 
 import com.github.nexus.configuration.Configuration;
+import com.github.nexus.keyenc.KeyEncryptor;
 import com.github.nexus.nacl.KeyPair;
 import com.github.nexus.nacl.NaclFacade;
 import org.slf4j.Logger;

--- a/nexus-keygen/src/test/java/com/github/nexus/keygen/KeyGeneratorTest.java
+++ b/nexus-keygen/src/test/java/com/github/nexus/keygen/KeyGeneratorTest.java
@@ -1,6 +1,7 @@
 package com.github.nexus.keygen;
 
 import com.github.nexus.configuration.Configuration;
+import com.github.nexus.keyenc.KeyEncryptor;
 import com.github.nexus.nacl.Key;
 import com.github.nexus.nacl.KeyPair;
 import com.github.nexus.nacl.NaclFacade;

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
         <module>nexus-security</module>
         <module>nexus-config</module>
         <module>nexus-config-cli</module>
+        <module>key-encryption</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Move the private key encryption/decryption into its own module, so that the generation of new keys doesn't need to be in the main artifact.