### PR TITLE
Clean up

### DIFF
--- a/application/src/main/java/com/github/tessera/exception/TesseraException.java
+++ b/application/src/main/java/com/github/tessera/exception/TesseraException.java
@@ -1,17 +1,12 @@
 package com.github.tessera.exception;
 
-
 public abstract class TesseraException extends RuntimeException {
 
-    public TesseraException(String message) {
+    public TesseraException(final String message) {
         super(message);
     }
 
-    public TesseraException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public TesseraException(Throwable cause) {
+    public TesseraException(final Throwable cause) {
         super(cause);
     }
     

--- a/application/src/main/java/com/github/tessera/node/PartyInfoStore.java
+++ b/application/src/main/java/com/github/tessera/node/PartyInfoStore.java
@@ -5,8 +5,9 @@ import com.github.tessera.node.model.Party;
 import com.github.tessera.node.model.PartyInfo;
 import com.github.tessera.node.model.Recipient;
 
-import java.util.Collections;
 import java.util.Set;
+
+import static java.util.Collections.emptySet;
 
 public class PartyInfoStore {
 
@@ -16,27 +17,22 @@ public class PartyInfoStore {
 
         final String advertisedUrl = configuration.getServerUri().toString();
 
-        this.partyInfo = new PartyInfo(advertisedUrl, Collections.emptySet(), Collections.emptySet());
+        this.partyInfo = new PartyInfo(advertisedUrl, emptySet(), emptySet());
     }
 
-    public void store(final PartyInfo partyInfoToUpdate) {
-        synchronized (partyInfo) {
-            final Set<Recipient> existingRecipients = this.partyInfo.getRecipients();
-            final Set<Recipient> newRecipients = partyInfoToUpdate.getRecipients();
+    public synchronized void store(final PartyInfo partyInfoToUpdate) {
+        final Set<Recipient> existingRecipients = this.partyInfo.getRecipients();
+        final Set<Recipient> newRecipients = partyInfoToUpdate.getRecipients();
 
-            existingRecipients.addAll(newRecipients);
+        existingRecipients.addAll(newRecipients);
 
-            final Set<Party> existingParties = this.partyInfo.getParties();
-            final Set<Party> newParties = partyInfoToUpdate.getParties();
-            existingParties.addAll(newParties);
-        }
+        final Set<Party> existingParties = this.partyInfo.getParties();
+        final Set<Party> newParties = partyInfoToUpdate.getParties();
+        existingParties.addAll(newParties);
     }
 
-    public PartyInfo getPartyInfo() {
-        synchronized (partyInfo) {
-            final PartyInfo partyInfoCopy = new PartyInfo(partyInfo);
-            return partyInfoCopy;
-        }
+    public synchronized PartyInfo getPartyInfo() {
+        return new PartyInfo(partyInfo);
     }
 
 }

--- a/application/src/main/java/com/github/tessera/transaction/exception/TransactionNotFoundException.java
+++ b/application/src/main/java/com/github/tessera/transaction/exception/TransactionNotFoundException.java
@@ -4,15 +4,8 @@ import com.github.tessera.exception.TesseraException;
 
 public class TransactionNotFoundException extends TesseraException {
 
-    public TransactionNotFoundException(String message) {
+    public TransactionNotFoundException(final String message) {
         super(message);
     }
 
-    public TransactionNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public TransactionNotFoundException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/application/src/test/java/com/github/tessera/transaction/exception/TransactionNotFoundExceptionTest.java
+++ b/application/src/test/java/com/github/tessera/transaction/exception/TransactionNotFoundExceptionTest.java
@@ -5,41 +5,16 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TransactionNotFoundExceptionTest {
-    public TransactionNotFoundExceptionTest() {
-    }
 
     @Test
     public void constructWithMessage() {
 
-        String message = "Some punk's busted up my ride!!";
+        final String message = "Some punk's busted up my ride!!";
 
-        TransactionNotFoundException transactionNotFoundException = new TransactionNotFoundException(message);
+        final TransactionNotFoundException testException = new TransactionNotFoundException(message);
 
-        assertThat(transactionNotFoundException.getMessage()).isEqualTo(message);
-
-
-    }
-
-    @Test
-    public void constructWithMessageAndCause() {
-
-        String message = "Some punk's busted up my ride!!";
-        Throwable cause = new Exception("OUCH");
-        TransactionNotFoundException transactionNotFoundException = new TransactionNotFoundException(message,cause);
-
-        assertThat(transactionNotFoundException.getMessage()).isEqualTo(message);
-        assertThat(transactionNotFoundException.getCause()).isSameAs(cause);
-    }
-
-
-    @Test
-    public void constructWithCause() {
-
-        Throwable cause = new Exception("OUCH");
-        TransactionNotFoundException transactionNotFoundException = new TransactionNotFoundException(cause);
-
-        assertThat(transactionNotFoundException.getMessage()).isEqualTo("java.lang.Exception: OUCH");
-        assertThat(transactionNotFoundException.getCause()).isSameAs(cause);
+        assertThat(testException.getMessage()).isEqualTo(message);
 
     }
+
 }


### PR DESCRIPTION
Synchronized on main PartyInfoStore as a simpler means of transaction
locking.
Cleaned up remaining exception types of unused constructors.