### PR TITLE
Fix HTTP header API annotation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,11 @@ cache:
   directories:
   - "$HOME/.m2"
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
 script:
-- mvn dependency:purge-local-repository -Dinclude=com.github.tessera -DresolutionFuzziness=groupId -Dverbose=true clean install
+- mvn install
+
+before_cache:
+- mvn dependency:purge-local-repository -Dinclude=com.github.tessera -DresolutionFuzziness=groupId -Dverbose=true
+
+after_success:
+- bash <(curl -s https://codecov.io/bash)

--- a/tessera-app/src/main/java/com/github/tessera/api/TransactionResource.java
+++ b/tessera-app/src/main/java/com/github/tessera/api/TransactionResource.java
@@ -169,14 +169,14 @@ public class TransactionResource {
     @Consumes(APPLICATION_OCTET_STREAM)
     @Produces(APPLICATION_OCTET_STREAM)
     public Response receiveRaw(
-            @ApiParam("Encoded Sender Public Key")
-            @NotNull @HeaderParam(value = "c11n-key") String senderKey,
+            @ApiParam("Encoded transaction hash")
+            @NotNull @HeaderParam(value = "c11n-key") String hash,
             @ApiParam("Encoded Recipient Public Key")
             @HeaderParam(value = "c11n-to") String recipientKey) {
 
         LOGGER.debug("Received receiveraw request");
 
-        final byte[] decodedKey = base64Decoder.decode(senderKey);
+        final byte[] decodedKey = base64Decoder.decode(hash);
 
         final Optional<byte[]> to = Optional
                 .ofNullable(recipientKey)

--- a/tessera-app/src/main/java/com/github/tessera/node/ClientFactory.java
+++ b/tessera-app/src/main/java/com/github/tessera/node/ClientFactory.java
@@ -15,7 +15,6 @@ public class ClientFactory {
     public ClientFactory(SSLContextFactory sslContextFactory) {
         this.sslContextFactory = Objects.requireNonNull(sslContextFactory);
     }
-
     
     public Client buildFrom(final ServerConfig config) {
         if (config.isSsl()) {
@@ -27,7 +26,5 @@ public class ClientFactory {
             return ClientBuilder.newClient();
         }
     }
-
-   
 
 }

--- a/tessera-app/src/main/java/com/github/tessera/node/PartyInfoPoller.java
+++ b/tessera-app/src/main/java/com/github/tessera/node/PartyInfoPoller.java
@@ -9,10 +9,10 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.net.ConnectException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -67,7 +67,7 @@ public class PartyInfoPoller implements Runnable {
 
         final byte[] encodedPartyInfo = partyInfoParser.to(partyInfo);
 
-        final Set<Party> partySet = partyInfo.getParties().stream().collect(Collectors.toSet());
+        final Set<Party> partySet = new HashSet<>(partyInfo.getParties());
 
         partySet.stream()
             .filter(party -> !party.getUrl().equals(partyInfo.getUrl()))

--- a/tessera-app/src/main/java/com/github/tessera/node/model/Party.java
+++ b/tessera-app/src/main/java/com/github/tessera/node/model/Party.java
@@ -16,10 +16,6 @@ public class Party {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-
         return (o instanceof Party) && Objects.equals(url, ((Party) o).url);
     }
 

--- a/tessera-app/src/main/java/com/github/tessera/node/model/Recipient.java
+++ b/tessera-app/src/main/java/com/github/tessera/node/model/Recipient.java
@@ -25,10 +25,6 @@ public class Recipient {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-
         if (!(o instanceof Recipient)) {
             return false;
         }

--- a/tessera-app/src/main/java/com/github/tessera/transaction/TransactionServiceImpl.java
+++ b/tessera-app/src/main/java/com/github/tessera/transaction/TransactionServiceImpl.java
@@ -81,6 +81,7 @@ public class TransactionServiceImpl implements TransactionService {
 
         final EncodedPayloadWithRecipients payloadWithRecipients
             = payloadEncoder.decodePayloadWithRecipients(encryptedTransaction.getEncodedPayload());
+
         final EncodedPayload encodedPayload = payloadWithRecipients.getEncodedPayload();
 
         final Key senderPubKey, recipientPubKey;

--- a/tessera-app/src/test/java/com/github/tessera/node/model/PartyTest.java
+++ b/tessera-app/src/test/java/com/github/tessera/node/model/PartyTest.java
@@ -10,7 +10,9 @@ public class PartyTest {
 
     @Test
     public void differentClassesAreNotEqual() {
-        final boolean isEqual = Objects.equals(new Party("partyurl"), "test");
+
+        final Object other =  "test";
+        final boolean isEqual = Objects.equals(new Party("partyurl"), other);
 
         assertThat(isEqual).isFalse();
     }
@@ -29,7 +31,6 @@ public class PartyTest {
         assertThat(party.getUrl())
             .isEqualTo("partyurl")
             .isSameAs("partyurl");
-
     }
 
     @Test
@@ -37,9 +38,7 @@ public class PartyTest {
 
         final Party party = new Party("partyurl");
 
-        assertThat(party)
-            .hasSameHashCodeAs(new Party("partyurl"));
-
+        assertThat(party).hasSameHashCodeAs(new Party("partyurl"));
     }
 
 }


### PR DESCRIPTION
Fix HTTP header API annotation and name to be correct.
Remove self testing in equals, as this will almost never happen.
Remove excessive whitespace.