### PR TITLE
Determine if we are the originator or recipient on decryption

### DIFF
--- a/tessera-app/src/main/java/com/github/tessera/enclave/EnclaveImpl.java
+++ b/tessera-app/src/main/java/com/github/tessera/enclave/EnclaveImpl.java
@@ -49,7 +49,7 @@ public class EnclaveImpl implements Enclave {
     public void delete(final byte[] hashBytes) {
         final MessageHash messageHash = new MessageHash(hashBytes);
 
-        transactionService.delete(messageHash);
+        this.transactionService.delete(messageHash);
     }
 
     @Override
@@ -121,9 +121,11 @@ public class EnclaveImpl implements Enclave {
     }
 
     @Override
-    public void resendAll(byte[] recipientPublicKey) {
-        Key recipient = new Key(recipientPublicKey);
-        Collection<EncodedPayloadWithRecipients> payloads = transactionService.retrieveAllForRecipient(recipient);
+    public void resendAll(final byte[] recipientPublicKey) {
+        final Key recipient = new Key(recipientPublicKey);
+
+        final Collection<EncodedPayloadWithRecipients> payloads
+            = this.transactionService.retrieveAllForRecipient(recipient);
 
         payloads.forEach(payload -> {
             payload.getRecipientKeys().forEach(recipientKey -> {

--- a/tessera-app/src/main/java/com/github/tessera/threading/TesseraScheduledExecutor.java
+++ b/tessera-app/src/main/java/com/github/tessera/threading/TesseraScheduledExecutor.java
@@ -39,11 +39,11 @@ public class TesseraScheduledExecutor {
      */
     @PostConstruct
     public void start() {
-        LOGGER.info("Starting {}", getClass().getSimpleName());
+        LOGGER.info("Starting {}", this.action.getClass().getSimpleName());
 
         final Runnable exceptionSafeRunnable = () -> {
             try {
-                action.run();
+                this.action.run();
             } catch (final Throwable ex) {
                 LOGGER.error("Error when executing action {}", action.getClass().getSimpleName());
                 LOGGER.error("Error when executing action", ex);
@@ -52,7 +52,7 @@ public class TesseraScheduledExecutor {
 
         this.executor.scheduleWithFixedDelay(exceptionSafeRunnable, rateInSeconds, rateInSeconds, TimeUnit.SECONDS);
 
-        LOGGER.info("Started {}", getClass().getSimpleName());
+        LOGGER.info("Started {}", this.action.getClass().getSimpleName());
     }
 
     /**
@@ -61,11 +61,11 @@ public class TesseraScheduledExecutor {
      */
     @PreDestroy
     public void stop() {
-        LOGGER.info("Stopping {}", getClass().getSimpleName());
+        LOGGER.info("Stopping {}", this.action.getClass().getSimpleName());
 
         this.executor.shutdown();
 
-        LOGGER.info("Stopped {}", getClass().getSimpleName());
+        LOGGER.info("Stopped {}", this.action.getClass().getSimpleName());
     }
 
 }


### PR DESCRIPTION
Changed way to determine whether we are the originator or recipient when decrypting a transaction.
Instead of checking for an empty recipient list (which may have been
the case of only sending a transaction to ourselves), check if the
sender key is one managed by this node.