### PR TITLE
Storage to jdbc support. 

### DIFF
--- a/config-cli/src/main/java/com/github/tessera/config/builder/ConfigBuilder.java
+++ b/config-cli/src/main/java/com/github/tessera/config/builder/ConfigBuilder.java
@@ -28,9 +28,7 @@ public class ConfigBuilder {
         final ConfigBuilder configBuilder = ConfigBuilder.create();
         configBuilder.unixSocketFile(Objects.toString(config.getUnixSocketFile()));
 
-        configBuilder.jdbcUrl(config.getJdbcConfig().getUrl())
-                .jdbcUsername(config.getJdbcConfig().getUsername())
-                .jdbcPassword(config.getJdbcConfig().getPassword())
+        configBuilder.jdbcConfig(config.getJdbcConfig())
                 .peers(config.getPeers()
                         .stream()
                         .map(Peer::getUrl)
@@ -64,6 +62,10 @@ public class ConfigBuilder {
     private String serverHostname;
 
     private Integer serverPort;
+
+    private String legacyStorage;
+
+    private JdbcConfig jdbcConfig;
 
     private String jdbcUsername;
 
@@ -153,20 +155,12 @@ public class ConfigBuilder {
         return this;
     }
 
-    public ConfigBuilder jdbcUsername(String jdbcUsername) {
-        this.jdbcUsername = jdbcUsername;
+    public ConfigBuilder jdbcConfig(JdbcConfig jdbcConfig) {
+        this.jdbcConfig = jdbcConfig;
         return this;
     }
 
-    public ConfigBuilder jdbcPassword(String jdbcPassword) {
-        this.jdbcPassword = jdbcPassword;
-        return this;
-    }
 
-    public ConfigBuilder jdbcUrl(String jdbcUrl) {
-        this.jdbcUrl = jdbcUrl;
-        return this;
-    }
 
     public ConfigBuilder peers(List<String> peers) {
         this.peers = peers;
@@ -210,8 +204,7 @@ public class ConfigBuilder {
 
     public Config build() {
 
-        final JdbcConfig jdbcConfig = new JdbcConfig(jdbcUsername, jdbcPassword, jdbcUrl);
-
+       
         boolean generateKeyStoreIfNotExisted = false;
 
         SslConfig sslConfig = new SslConfig(

--- a/config-cli/src/main/java/com/github/tessera/config/builder/ConfigBuilderException.java
+++ b/config-cli/src/main/java/com/github/tessera/config/builder/ConfigBuilderException.java
@@ -1,5 +1,5 @@
 
-package com.github.tessera.config.cli;
+package com.github.tessera.config.builder;
 
 
 public class ConfigBuilderException extends RuntimeException {

--- a/config-cli/src/main/java/com/github/tessera/config/builder/JdbcConfigFactory.java
+++ b/config-cli/src/main/java/com/github/tessera/config/builder/JdbcConfigFactory.java
@@ -1,0 +1,37 @@
+
+package com.github.tessera.config.builder;
+
+import com.github.tessera.config.JdbcConfig;
+import java.util.Optional;
+
+
+public interface JdbcConfigFactory {
+
+    static JdbcConfig fromLegacyStorageString(String storage) {
+        
+        Optional.ofNullable(storage)
+                .orElseThrow(IllegalArgumentException::new);
+        
+        if(storage.startsWith("jdbc")) {
+            return new JdbcConfig(null, null, storage);
+        }
+
+        if(storage.startsWith("sqlite")) {
+            return new JdbcConfig(null, null, String.format("jdbc:%s", storage));
+        }
+        
+        if(storage.startsWith("memory")) {
+            return new JdbcConfig(null, null, "jdbc:h2:mem:tessera");
+        }
+
+        throw new UnsupportedOperationException(String.format("%s is not a supported storage option.", storage));
+        
+        
+        
+    }
+    
+    
+    
+
+    
+}

--- a/config-cli/src/main/java/com/github/tessera/config/cli/TomlConfigFactory.java
+++ b/config-cli/src/main/java/com/github/tessera/config/cli/TomlConfigFactory.java
@@ -7,6 +7,7 @@ import com.github.tessera.config.ConfigFactory;
 import com.github.tessera.config.KeyDataConfig;
 import com.github.tessera.config.SslAuthenticationMode;
 import com.github.tessera.config.SslTrustMode;
+import com.github.tessera.config.builder.JdbcConfigFactory;
 import com.github.tessera.config.util.JaxbUtil;
 import com.github.tessera.io.FilesDelegate;
 import com.github.tessera.io.IOCallback;
@@ -22,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -107,7 +109,7 @@ public class TomlConfigFactory implements ConfigFactory {
 
         List<String> tlsserverchain = toml.getList("tlsserverchain", Collections.EMPTY_LIST);
 
-        String storage = toml.getString("storage", "dir:storage");
+        String storage = toml.getString("storage");
 
         //verbosity
         final String tlsservercert = toml.getString("tlsservercert", "tls-server-cert.pem");
@@ -121,6 +123,7 @@ public class TomlConfigFactory implements ConfigFactory {
         final String tlsknownclients = toml.getString("tlsknownclients", "tls-known-clients");
 
         ConfigBuilder configBuilder = ConfigBuilder.create()
+        
                 .serverHostname(url)
                 .unixSocketFile(socket)
                 .sslAuthenticationMode(SslAuthenticationMode.valueOf(tls))
@@ -135,6 +138,9 @@ public class TomlConfigFactory implements ConfigFactory {
                 .knownServersFile(tlsknownservers)
                 .peers(othernodes);
 
+        Optional.ofNullable(storage)
+                .map(JdbcConfigFactory::fromLegacyStorageString).ifPresent(configBuilder::jdbcConfig);
+        
         return configBuilder.build();
     }
 

--- a/config-cli/src/test/java/com/github/tessera/config/builder/ConfigBuilderExceptionTest.java
+++ b/config-cli/src/test/java/com/github/tessera/config/builder/ConfigBuilderExceptionTest.java
@@ -1,5 +1,5 @@
 
-package com.github.tessera.config.cli;
+package com.github.tessera.config.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;

--- a/config-cli/src/test/java/com/github/tessera/config/builder/ConfigBuilderTest.java
+++ b/config-cli/src/test/java/com/github/tessera/config/builder/ConfigBuilderTest.java
@@ -2,6 +2,7 @@ package com.github.tessera.config.builder;
 
 
 import com.github.tessera.config.Config;
+import com.github.tessera.config.JdbcConfig;
 import com.github.tessera.config.SslAuthenticationMode;
 import com.github.tessera.config.SslTrustMode;
 import java.io.StringWriter;
@@ -18,9 +19,7 @@ import org.xmlunit.diff.Diff;
 public class ConfigBuilderTest {
 
     private final ConfigBuilder builderWithValidValues = ConfigBuilder.create()
-            .jdbcUrl("jdbc:bogus")
-            .jdbcUsername("jdbcUsername")
-            .jdbcPassword("jdbcPassword")
+            .jdbcConfig(new JdbcConfig("jdbcUsername", "jdbcPassword", "jdbc:bogus"))
             .peers(Collections.EMPTY_LIST)
             .serverPort(892)
             .sslAuthenticationMode(SslAuthenticationMode.STRICT)

--- a/config-cli/src/test/java/com/github/tessera/config/builder/JdbcConfigFactoryTest.java
+++ b/config-cli/src/test/java/com/github/tessera/config/builder/JdbcConfigFactoryTest.java
@@ -1,0 +1,54 @@
+package com.github.tessera.config.builder;
+
+import com.github.tessera.config.JdbcConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+public class JdbcConfigFactoryTest {
+
+    @Test
+    public void sqllite() {
+
+        JdbcConfig jdbcConfig = JdbcConfigFactory.fromLegacyStorageString("sqlite:somepath");
+
+        assertThat(jdbcConfig.getUrl())
+                .isEqualTo("jdbc:sqlite:somepath");
+        assertThat(jdbcConfig.getUsername()).isNull();
+        assertThat(jdbcConfig.getPassword()).isNull();
+
+    }
+
+    @Test
+    public void memory() {
+
+        JdbcConfig jdbcConfig = JdbcConfigFactory.fromLegacyStorageString("memory");
+
+        assertThat(jdbcConfig.getUrl())
+                .isEqualTo("jdbc:h2:mem:tessera");
+        assertThat(jdbcConfig.getUsername()).isNull();
+        assertThat(jdbcConfig.getPassword()).isNull();
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullIsNotAllowed() {
+        JdbcConfigFactory.fromLegacyStorageString(null);
+
+    }
+
+    @Test
+    public void jdbcUrlsAreLeftUntouched() {
+        JdbcConfig jdbcConfig = JdbcConfigFactory.fromLegacyStorageString("jdbc:somedb:somepath");
+
+        assertThat(jdbcConfig.getUrl()).isEqualTo("jdbc:somedb:somepath");
+        assertThat(jdbcConfig.getUsername()).isNull();
+        assertThat(jdbcConfig.getPassword()).isNull();
+    }
+    
+    @Test(expected = UnsupportedOperationException.class)
+    public void unknownIsNotSupported() {
+        JdbcConfigFactory.fromLegacyStorageString("unknown");
+    }
+
+
+}

--- a/config-cli/src/test/java/com/github/tessera/config/cli/LegacyCliAdapterTest.java
+++ b/config-cli/src/test/java/com/github/tessera/config/cli/LegacyCliAdapterTest.java
@@ -3,8 +3,6 @@ package com.github.tessera.config.cli;
 import com.github.tessera.config.builder.ConfigBuilder;
 import com.github.tessera.config.Config;
 import com.github.tessera.config.Peer;
-import com.github.tessera.config.SslAuthenticationMode;
-import com.github.tessera.config.SslTrustMode;
 import com.github.tessera.config.test.FixtureUtil;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,25 +18,7 @@ import static org.mockito.Mockito.when;
 
 public class LegacyCliAdapterTest {
 
-    private final ConfigBuilder builderWithValidValues = ConfigBuilder.create()
-            .jdbcUrl("jdbc:bogus")
-            .jdbcUsername("jdbcUsername")
-            .jdbcPassword("jdbcPassword")
-            .peers(Arrays.asList("http://one.com:8989/one", "http://two.com:9929/two"))
-            .serverPort(892)
-            .sslAuthenticationMode(SslAuthenticationMode.STRICT)
-            .unixSocketFile("somepath.ipc")
-            .serverHostname("http://bogus.com:928")
-            .sslServerKeyStorePath("sslServerKeyStorePath")
-            .sslServerTrustMode(SslTrustMode.TOFU)
-            .sslServerTrustStorePath("sslServerTrustStorePath")
-            .sslServerTrustStorePath("sslServerKeyStorePath")
-            .sslClientKeyStorePath("sslClientKeyStorePath")
-            .sslClientTrustStorePath("sslClientTrustStorePath")
-            .sslClientKeyStorePassword("sslClientKeyStorePassword")
-            .sslClientTrustStorePassword("sslClientTrustStorePassword")
-            .knownClientsFile("knownClientsFile")
-            .knownServersFile("knownServersFile");
+    private final ConfigBuilder builderWithValidValues = FixtureUtil.builderWithValidValues();
 
     private final LegacyCliAdapter instance = new LegacyCliAdapter();
 
@@ -92,9 +72,14 @@ public class LegacyCliAdapterTest {
                                 .toArray(new String[0])
                 );
 
+        
+        when(commandLine.getOptionValue("storage")).thenReturn("sqlite:somepath");
+        
         when(commandLine.getOptionValues("publickeys"))
                 .thenReturn(new String[]{"ONE", "TWO"});
 
+        
+        
         List<Path> privateKeyPaths = Arrays.asList(
                 Files.createTempFile("applyOverrides1", ".txt"),
                 Files.createTempFile("applyOverrides2", ".txt")
@@ -128,6 +113,8 @@ public class LegacyCliAdapterTest {
         assertThat(result.getUnixSocketFile()).isEqualTo(Paths.get(unixSocketFileOverride));
         assertThat(result.getPeers()).containsExactly(overridePeers.toArray(new Peer[0]));
         assertThat(result.getKeys()).hasSize(2);
+        assertThat(result.getJdbcConfig()).isNotNull();
+        assertThat(result.getJdbcConfig().getUrl()).isEqualTo("jdbc:sqlite:somepath");
         
         
         Files.deleteIfExists(privateKeyPasswordFile);
@@ -160,6 +147,8 @@ public class LegacyCliAdapterTest {
         assertThat(result.getPeers())
                 .containsOnlyElementsOf(expectedValues.getPeers());
 
+        assertThat(result.getJdbcConfig().getUrl()).isEqualTo("jdbc:bogus");
+        
     }
 
 }

--- a/config-cli/src/test/java/com/github/tessera/config/test/FixtureUtil.java
+++ b/config-cli/src/test/java/com/github/tessera/config/test/FixtureUtil.java
@@ -1,5 +1,10 @@
 package com.github.tessera.config.test;
 
+import com.github.tessera.config.JdbcConfig;
+import com.github.tessera.config.SslAuthenticationMode;
+import com.github.tessera.config.SslTrustMode;
+import com.github.tessera.config.builder.ConfigBuilder;
+import java.util.Arrays;
 import javax.json.Json;
 import javax.json.JsonObject;
 
@@ -23,6 +28,27 @@ public class FixtureUtil {
 
     public static JsonObject createLockedPrivateKey() {
         return LOCKED_PRIVATE_KEY_DATA;
+    }
+
+    public static ConfigBuilder builderWithValidValues() {
+
+        return ConfigBuilder.create()
+                .jdbcConfig(new JdbcConfig("jdbcUsername", "jdbcPassword", "jdbc:bogus"))
+                .peers(Arrays.asList("http://one.com:8989/one", "http://two.com:9929/two"))
+                .serverPort(892)
+                .sslAuthenticationMode(SslAuthenticationMode.STRICT)
+                .unixSocketFile("somepath.ipc")
+                .serverHostname("http://bogus.com:928")
+                .sslServerKeyStorePath("sslServerKeyStorePath")
+                .sslServerTrustMode(SslTrustMode.TOFU)
+                .sslServerTrustStorePath("sslServerTrustStorePath")
+                .sslServerTrustStorePath("sslServerKeyStorePath")
+                .sslClientKeyStorePath("sslClientKeyStorePath")
+                .sslClientTrustStorePath("sslClientTrustStorePath")
+                .sslClientKeyStorePassword("sslClientKeyStorePassword")
+                .sslClientTrustStorePassword("sslClientTrustStorePassword")
+                .knownClientsFile("knownClientsFile")
+                .knownServersFile("knownServersFile");
     }
 
 }

--- a/config-cli/src/test/resources/sample.conf
+++ b/config-cli/src/test/resources/sample.conf
@@ -109,7 +109,7 @@ alwayssendto = []
 ##   - sqlite:path (SQLite - experimental)
 ##
 ## Default: "dir:storage"
-storage = "dir:storage"
+storage = "memory"
 
 ## Verbosity level (each level includes all prior levels)
 ##   - 0: Only fatal errors


### PR DESCRIPTION
Delegate creation of jdbc config object  to factory in order to support legacy storage config option. 

dir:storage is not supported for the time being and issue has been raised as a potential feature. 