### PR TITLE
Protect Private API

### DIFF
--- a/tessera-app/src/main/java/com/quorum/tessera/api/TransactionResource.java
+++ b/tessera-app/src/main/java/com/quorum/tessera/api/TransactionResource.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.api;
 
+import com.quorum.tessera.api.filter.PrivateApi;
 import com.quorum.tessera.api.model.*;
 import com.quorum.tessera.enclave.Enclave;
 import com.quorum.tessera.enclave.model.MessageHash;
@@ -47,12 +48,14 @@ public class TransactionResource {
         this.enclave = requireNonNull(enclave, "enclave must not be null");
         this.base64Decoder = requireNonNull(base64Decoder, "decoder must not be null");
     }
+
     @ApiOperation(value = "Send private transaction payload", produces = "Encrypted payload")
     @ApiResponses({
         @ApiResponse(code = 200, response = SendResponse.class, message = "Send response"),
         @ApiResponse(code = 400, message = "For unknown and unknown keys")
     })
     @POST
+    @PrivateApi
     @Path("send")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
@@ -88,12 +91,14 @@ public class TransactionResource {
                 .build();
 
     }
+
     @ApiOperation(value = "Send private transaction payload", produces = "Encrypted payload")
     @ApiResponses({
         @ApiResponse(code = 200, message = "Encoded Key", response = String.class),
         @ApiResponse(code = 500, message = "Unknown server error")
     })
     @POST
+    @PrivateApi
     @Path("sendraw")
     @Consumes(APPLICATION_OCTET_STREAM)
     @Produces(TEXT_PLAIN)
@@ -129,6 +134,7 @@ public class TransactionResource {
         @ApiResponse(code = 200, response = ReceiveResponse.class, message = "Receive Response object")
     })
     @GET
+    @PrivateApi
     @Path("/transaction/{hash}")
     @Produces(APPLICATION_JSON)
     public Response receive(
@@ -160,6 +166,7 @@ public class TransactionResource {
 
     @GET
     @Deprecated
+    @PrivateApi
     @Path("/receive")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)

--- a/tessera-app/src/main/java/com/quorum/tessera/api/filter/PrivateApi.java
+++ b/tessera-app/src/main/java/com/quorum/tessera/api/filter/PrivateApi.java
@@ -1,0 +1,16 @@
+package com.quorum.tessera.api.filter;
+
+import javax.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A name binding that is to be applied to endpoints under the Private API
+ */
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface PrivateApi {
+}

--- a/tessera-app/src/main/java/com/quorum/tessera/api/filter/PrivateApiFilter.java
+++ b/tessera-app/src/main/java/com/quorum/tessera/api/filter/PrivateApiFilter.java
@@ -1,0 +1,62 @@
+package com.quorum.tessera.api.filter;
+
+import com.quorum.tessera.config.ServerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+@PrivateApi
+public class PrivateApiFilter implements ContainerRequestFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PrivateApiFilter.class);
+
+    private HttpServletRequest httpServletRequest;
+
+    private final String hostname;
+
+    public PrivateApiFilter(final ServerConfig serverConfig) {
+        this.hostname = serverConfig.getServerUri().getHost();
+    }
+
+    /**
+     * Extract the callers hostname and address,
+     * and check it against our configured hostname to check they are the same
+     * <p>
+     * If the host is not the same as ours, finish the filter chain here and return an Unauthorized response
+     *
+     * @param requestContext the context of the current request
+     */
+    @Override
+    public void filter(final ContainerRequestContext requestContext) {
+
+        if(this.httpServletRequest == null) {
+            LOGGER.debug("No servlet available, could not determine request origin. Allowing...");
+            return;
+        }
+
+        final String remoteAddress = httpServletRequest.getRemoteAddr();
+        final String remoteHost = httpServletRequest.getRemoteHost();
+
+        final boolean allowed = hostname.equals(remoteAddress) || hostname.equals(remoteHost);
+
+        if (!allowed) {
+            requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
+        }
+
+    }
+
+    /**
+     * Apply the current HTTP context to the filter, to check the remote host
+     *
+     * @param request the request to be filtered
+     */
+    @Context
+    public void setHttpServletRequest(final HttpServletRequest request) {
+        this.httpServletRequest = request;
+    }
+}

--- a/tessera-app/src/main/resources/tessera-spring.xml
+++ b/tessera-app/src/main/resources/tessera-spring.xml
@@ -113,6 +113,12 @@
         <constructor-arg ref="config"/>
     </bean>
 
+    <bean class="com.quorum.tessera.api.filter.PrivateApiFilter">
+        <constructor-arg>
+            <bean factory-bean="config" factory-method="getServerConfig"/>
+        </constructor-arg>
+    </bean>
+
     <bean name="payloadEncoder" class="com.quorum.tessera.transaction.PayloadEncoderImpl"/>
 
     <bean name="transactionService" class="com.quorum.tessera.transaction.TransactionServiceImpl">

--- a/tessera-app/src/test/java/com/quorum/tessera/api/filter/PrivateApiFilterTest.java
+++ b/tessera-app/src/test/java/com/quorum/tessera/api/filter/PrivateApiFilterTest.java
@@ -1,0 +1,84 @@
+package com.quorum.tessera.api.filter;
+
+import com.quorum.tessera.config.ServerConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class PrivateApiFilterTest {
+
+    private ContainerRequestContext ctx;
+
+    private PrivateApiFilter filter;
+
+    @Before
+    public void init() throws URISyntaxException {
+        final ServerConfig serverConfig = mock(ServerConfig.class);
+        final URI testUri = new URI("http://localhost:8080");
+        when(serverConfig.getServerUri()).thenReturn(testUri);
+
+        this.filter = new PrivateApiFilter(serverConfig);
+
+        this.ctx = mock(ContainerRequestContext.class);
+    }
+
+    @Test
+    public void hostNotALocalAddressGetsRejected() {
+
+        final Response expectedResponse = Response.status(Response.Status.UNAUTHORIZED).build();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        doReturn("someotherhost").when(request).getRemoteAddr();
+        doReturn("someotherhost").when(request).getRemoteHost();
+
+        filter.setHttpServletRequest(request);
+
+        filter.filter(ctx);
+
+        verify(request).getRemoteHost();
+        verify(request).getRemoteAddr();
+
+        final ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(ctx).abortWith(captor.capture());
+
+        assertThat(captor.getValue()).isEqualToComparingFieldByFieldRecursively(expectedResponse);
+
+    }
+
+    @Test
+    public void hostThatIsLocalAddressGetsAccepted() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        doReturn("localhost").when(request).getRemoteAddr();
+
+        filter.setHttpServletRequest(request);
+
+        filter.filter(ctx);
+
+        verify(request).getRemoteHost();
+        verify(request).getRemoteAddr();
+        verifyZeroInteractions(ctx);
+
+    }
+
+    @Test
+    public void noServletAllowsRequest() {
+
+        filter.setHttpServletRequest(null);
+
+        filter.filter(ctx);
+
+        verifyZeroInteractions(ctx);
+
+    }
+
+}

--- a/tessera-app/src/test/java/com/quorum/tessera/api/filter/PrivateApiFilterTest.java
+++ b/tessera-app/src/test/java/com/quorum/tessera/api/filter/PrivateApiFilterTest.java
@@ -71,6 +71,22 @@ public class PrivateApiFilterTest {
     }
 
     @Test
+    public void hostThatIsLocalHostnameGetsAccepted() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        doReturn("localhost").when(request).getRemoteHost();
+        doReturn("wrongvalue").when(request).getRemoteAddr();
+
+        filter.setHttpServletRequest(request);
+
+        filter.filter(ctx);
+
+        verify(request).getRemoteHost();
+        verify(request).getRemoteAddr();
+        verifyZeroInteractions(ctx);
+
+    }
+
+    @Test
     public void noServletAllowsRequest() {
 
         filter.setHttpServletRequest(null);


### PR DESCRIPTION
Protect the Private API from being called externally.
Only requests from the same configured host will be allowed, which allows the socket requests to be accepted.