### PR TITLE
Prompt for password confirmation on private keys

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/keys/KeyGeneratorImpl.java
+++ b/config/src/main/java/com/quorum/tessera/config/keys/KeyGeneratorImpl.java
@@ -42,9 +42,7 @@ public class KeyGeneratorImpl implements KeyGenerator {
     @Override
     public KeyData generate(final String filename) {
 
-        System.out.println("Enter a password if you want to lock the private key or leave blank");
-
-        final String password = this.passwordReader.readPassword();
+        final String password = this.getPassword();
 
         final KeyPair generated = this.nacl.generateNewKeys();
 
@@ -149,6 +147,26 @@ public class KeyGeneratorImpl implements KeyGenerator {
         JaxbUtil.marshal(privateKey, outputStream);
 
         return new String(outputStream.toByteArray());
+
+    }
+
+    private String getPassword() {
+
+        for(;;) {
+
+            System.out.println("Enter a password if you want to lock the private key or leave blank");
+            final String password = this.passwordReader.readPassword();
+
+            System.out.println("Please re-enter the password (or lack of) to confirm");
+            final String passwordCheck = this.passwordReader.readPassword();
+
+            if(Objects.equals(password, passwordCheck)) {
+                return password;
+            } else {
+                System.out.println("Passwords did not match, try again...");
+            }
+
+        }
 
     }
 

--- a/config/src/main/java/com/quorum/tessera/config/util/PasswordReader.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/PasswordReader.java
@@ -12,11 +12,11 @@ public class PasswordReader {
 
     private final Console console;
 
-    private final InputStream systemIn;
+    private final Scanner systemIn;
 
     public PasswordReader(final Console console, final InputStream systemIn) {
         this.console = console;
-        this.systemIn = systemIn;
+        this.systemIn = new Scanner(systemIn);
     }
 
     /**
@@ -25,7 +25,7 @@ public class PasswordReader {
      */
     public String readPassword() {
         if(this.console == null) {
-            return new Scanner(this.systemIn).nextLine();
+            return this.systemIn.nextLine();
         }
 
         final char[] consolePassword = this.console.readPassword();

--- a/config/src/test/java/com/quorum/tessera/config/ConfigFactoryTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ConfigFactoryTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class ConfigFactoryTest {
 
@@ -23,17 +24,14 @@ public class ConfigFactoryTest {
         InputStream inputStream = getClass().getResourceAsStream("/sample.json");
 
         Config config = configFactory.create(inputStream);
+
         assertThat(config).isNotNull();
-
         assertThat(config.isUseWhiteList()).isFalse();
-
         assertThat(config.getJdbcConfig().getUsername()).isEqualTo("scott");
-
         assertThat(config.getPeers()).hasSize(2);
-
         assertThat(config.getKeys().getKeyData()).hasSize(1);
 
-        KeyData keyData = config.getKeys().getKeyData().get(0);
+        final KeyData keyData = config.getKeys().getKeyData().get(0);
 
         assertThat(keyData.getConfig()).isNotNull();
 
@@ -52,23 +50,28 @@ public class ConfigFactoryTest {
 
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void createFromSampleJaxbException() {
 
-        ConfigFactory configFactory = ConfigFactory.create();
-
+        final ConfigFactory configFactory = ConfigFactory.create();
         assertThat(configFactory).isExactlyInstanceOf(JaxbConfigFactory.class);
 
-        InputStream inputStream = new ByteArrayInputStream("BANG".getBytes());
+        final InputStream inputStream = new ByteArrayInputStream("BANG".getBytes());
 
-        configFactory.create(inputStream);
-
+        final Throwable throwable = catchThrowable(() -> configFactory.create(inputStream));
+        assertThat(throwable).isInstanceOf(ConfigException.class);
     }
 
     @Test
     public void createFromKeyGenSample() throws Exception {
 
-        final InputStream tempSystemIn = new ByteArrayInputStream((UUID.randomUUID().toString() + System.lineSeparator()).getBytes());
+        final Path tempFolder = Files.createTempDirectory(UUID.randomUUID().toString()).toAbsolutePath();
+
+        final String password = UUID.randomUUID().toString();
+
+        final InputStream tempSystemIn = new ByteArrayInputStream(
+            (password + System.lineSeparator() + password + System.lineSeparator()).getBytes()
+        );
 
         final InputStream oldSystemIn = System.in;
         System.setIn(tempSystemIn);
@@ -76,11 +79,9 @@ public class ConfigFactoryTest {
         final ConfigFactory configFactory = ConfigFactory.create();
         assertThat(configFactory).isExactlyInstanceOf(JaxbConfigFactory.class);
 
-        final Path keyFile = Paths.get(getClass().getResource("/lockedprivatekey.json").toURI());
-
         final Path configFile = Paths.get(getClass().getResource("/sample-private-keygen.json").toURI());
 
-        Config config = configFactory.create(Files.newInputStream(configFile), UUID.randomUUID().toString());
+        Config config = configFactory.create(Files.newInputStream(configFile), tempFolder.toString());
 
         assertThat(config).isNotNull();
         assertThat(config.getKeys().getKeyData()).hasSize(1);


### PR DESCRIPTION
When prompting the user for a password, prompt them again to confirm (to make sure they typed it correctly), and retry this until the passwords match.