### PR TITLE
Don't create inline password list on migration

### DIFF
--- a/config-migration/src/main/java/com/quorum/tessera/config/builder/KeyDataBuilder.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/builder/KeyDataBuilder.java
@@ -54,16 +54,12 @@ public class KeyDataBuilder {
             throw new ConfigException(new RuntimeException("Different amount of public and private keys supplied"));
         }
 
-        if(publicKeys.isEmpty()) {
-            return new KeyConfiguration(null, null, Collections.emptyList());
-        }
-
         final List<KeyData> keyData = IntStream
             .range(0, publicKeys.size())
             .mapToObj(i -> new KeyData(null, null, null, Paths.get(workdir, privateKeys.get(i)), Paths.get(workdir, publicKeys.get(i))))
             .collect(toList());
 
-        return new KeyConfiguration(privateKeyPasswordFile, Collections.emptyList(), keyData);
+        return new KeyConfiguration(privateKeyPasswordFile, null, keyData);
     }
 
 }


### PR DESCRIPTION
Remove check for no keys provided, since the stream will handle it and return an empty list.
Set the inline passwords to be null on migration.