### PR TITLE
Attach pass to generated key when starting app

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/JaxbConfigFactory.java
+++ b/config/src/main/java/com/quorum/tessera/config/JaxbConfigFactory.java
@@ -12,7 +12,6 @@ import java.util.stream.Stream;
 
 public class JaxbConfigFactory implements ConfigFactory {
 
-
     private final KeyGenerator generator = KeyGeneratorFactory.newFactory().create();
     
     @Override
@@ -21,27 +20,7 @@ public class JaxbConfigFactory implements ConfigFactory {
         final List<KeyData> newKeys = Stream
             .of(filenames)
             .map(name -> generator.generate(name, keygenConfig))
-            .map(kd -> new KeyData(
-                    new KeyDataConfig(
-                        new PrivateKeyData(
-                            kd.getConfig().getValue(),
-                            kd.getConfig().getSnonce(),
-                            kd.getConfig().getAsalt(),
-                            kd.getConfig().getSbox(),
-                            kd.getConfig().getArgonOptions(),
-                            null
-                        ),
-                        kd.getConfig().getType()
-                    ),
-                    kd.getPrivateKey(),
-                    kd.getPublicKey(),
-                    kd.getPrivateKeyPath(),
-                    kd.getPublicKeyPath()
-                )
-            )
             .collect(Collectors.toList());
-
-
 
         final Config config = JaxbUtil.unmarshal(configData, Config.class);
 

--- a/config/src/main/java/com/quorum/tessera/config/adapters/KeyDataAdapter.java
+++ b/config/src/main/java/com/quorum/tessera/config/adapters/KeyDataAdapter.java
@@ -125,11 +125,17 @@ public class KeyDataAdapter extends XmlAdapter<KeyData, KeyData> {
             return keyData;
         }
 
+        if(keyData.getPrivateKeyPath()!=null || keyData.getPublicKeyPath()!=null) {
+            return new KeyData(
+                null, null, null, keyData.getPrivateKeyPath(), keyData.getPublicKeyPath()
+            );
+        }
+
         if (keyData.getConfig().getType() != PrivateKeyType.UNLOCKED) {
             return new KeyData(
                     new KeyDataConfig(
                             new PrivateKeyData(
-                                    keyData.getConfig().getPrivateKeyData().getValue(),
+                                    null,
                                     keyData.getConfig().getPrivateKeyData().getSnonce(),
                                     keyData.getConfig().getPrivateKeyData().getAsalt(),
                                     keyData.getConfig().getPrivateKeyData().getSbox(),

--- a/config/src/main/java/com/quorum/tessera/config/keys/KeyGeneratorImpl.java
+++ b/config/src/main/java/com/quorum/tessera/config/keys/KeyGeneratorImpl.java
@@ -135,7 +135,7 @@ public class KeyGeneratorImpl implements KeyGenerator {
                     keyData.getConfig().getAsalt(),
                     keyData.getConfig().getSbox(),
                     keyData.getConfig().getArgonOptions(),
-                    null
+                    keyData.getConfig().getPassword()
                 ),
                 LOCKED
             );

--- a/config/src/test/java/com/quorum/tessera/config/adapters/KeyDataAdapterTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/adapters/KeyDataAdapterTest.java
@@ -276,4 +276,31 @@ public class KeyDataAdapterTest {
 
 
     }
+
+    @Test
+    public void pathsSetDoesntReturnWholeConfig() {
+        final KeyData keyData = new KeyData(
+            new KeyDataConfig(
+                new PrivateKeyData(
+                    null,
+                    "x3HUNXH6LQldKtEv3q0h0hR4S12Ur9pC",
+                    "7Sem2tc6fjEfW3yYUDN/kSslKEW0e1zqKnBCWbZu2Zw=",
+                    "d0CmRus0rP0bdc7P7d/wnOyEW14pwFJmcLbdu2W3HmDNRWVJtoNpHrauA/Sr5Vxc",
+                    new ArgonOptions("id", 10, 1048576, 4),
+                    null
+                ),
+                PrivateKeyType.LOCKED
+            ),
+            null,
+            "PUB", Paths.get("priv"), Paths.get("pub")
+        );
+
+        final KeyData result = this.adapter.marshal(keyData);
+
+        assertThat(result.getPrivateKeyPath()).isEqualTo(Paths.get("priv"));
+        assertThat(result.getPublicKeyPath()).isEqualTo(Paths.get("pub"));
+        assertThat(result.getPrivateKey()).isNull();
+        assertThat(result.getPublicKey()).isNull();
+        assertThat(result.getConfig()).isNull();
+    }
 }


### PR DESCRIPTION
Attach password to generated key when starting the application at same time.
When marshalling keys, remove unwanted parameters.