### PR TITLE
Disable h2 recover tests

### DIFF
--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RecoverIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RecoverIT.java
@@ -340,12 +340,11 @@ public class RecoverIT {
   @Parameterized.Parameters(name = "{0}")
   public static List<TestConfig> configs() {
     return List.of(
-        new TestConfig(DBType.H2, true),
-        new TestConfig(DBType.H2, false),
+        //        new TestConfig(DBType.H2, true),
+        //        new TestConfig(DBType.H2, false),
         //        new TestConfig(DBType.HSQL, true),
         //        new TestConfig(DBType.HSQL, false),
-        new TestConfig(DBType.SQLITE, true),
-        new TestConfig(DBType.SQLITE, false));
+        new TestConfig(DBType.SQLITE, true), new TestConfig(DBType.SQLITE, false));
   }
 
   static class TestConfig {


### PR DESCRIPTION
These tests are flaky (failing randomly due to DB connection errors) and take a long time to run.  The core recovery functionality is covered by the SQLITE tests.  Disabling should increase CI build stability and reduce CI build times.