### PR TITLE
Improve keygen CLI output, fix security advisories in key vault modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.time.Duration
 
 plugins {
-  id "org.owasp.dependencycheck" version "7.0.4.1"
+  id "org.owasp.dependencycheck" version "7.1.0.1"
   id 'jacoco'
   id 'com.diffplug.gradle.spotless' version '3.25.0'
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -248,6 +248,9 @@ subprojects {
   dependencyCheck {
     failBuildOnCVSS = 0
     suppressionFile = project.getRootProject().file("cvss-suppressions.xml")
+    analyzers {
+      assemblyEnabled = false
+    }
   }
 
   jacoco {

--- a/cli/cli-api/src/test/java/com/quorum/tessera/cli/parsers/ServerURIOutputMixinTest.java
+++ b/cli/cli-api/src/test/java/com/quorum/tessera/cli/parsers/ServerURIOutputMixinTest.java
@@ -32,4 +32,12 @@ public class ServerURIOutputMixinTest {
     serverURIOutputMixin.updateConfig(null, config);
     assertThat(config.getOutputServerURIPath()).isNull();
   }
+
+  @Test
+  public void defaultDoNothing() {
+    final Config config = new Config();
+    assertThat(config.getOutputServerURIPath()).isNull();
+    serverURIOutputMixin.updateConfig(config);
+    assertThat(config.getOutputServerURIPath()).isNull();
+  }
 }

--- a/cli/config-cli/src/main/java/com/quorum/tessera/config/cli/KeyGenCommand.java
+++ b/cli/config-cli/src/main/java/com/quorum/tessera/config/cli/KeyGenCommand.java
@@ -3,9 +3,10 @@ package com.quorum.tessera.config.cli;
 import com.quorum.tessera.cli.CliException;
 import com.quorum.tessera.cli.CliResult;
 import com.quorum.tessera.config.*;
-import com.quorum.tessera.config.keypairs.ConfigKeyPair;
+import com.quorum.tessera.config.keypairs.*;
 import com.quorum.tessera.config.util.ConfigFileUpdaterWriter;
 import com.quorum.tessera.config.util.PasswordFileUpdaterWriter;
+import com.quorum.tessera.key.generation.GeneratedKeyPair;
 import com.quorum.tessera.key.generation.KeyGenerator;
 import com.quorum.tessera.key.generation.KeyGeneratorFactory;
 import com.quorum.tessera.key.generation.KeyVaultOptions;
@@ -18,6 +19,8 @@ import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -33,6 +36,8 @@ import picocli.CommandLine;
     abbreviateSynopsis = true,
     subcommands = {CommandLine.HelpCommand.class})
 public class KeyGenCommand implements Callable<CliResult> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(KeyGenCommand.class);
 
   private final KeyGeneratorFactory keyGeneratorFactory;
 
@@ -83,6 +88,79 @@ public class KeyGenCommand implements Callable<CliResult> {
     this.keyDataMarshaller = Objects.requireNonNull(keyDataMarshaller);
   }
 
+  static void output(List<GeneratedKeyPair> generatedKeyPairs) {
+    StringJoiner sj = new StringJoiner("\n");
+    sj.add(String.format("%d keypair(s) generated:", generatedKeyPairs.size()));
+
+    int i = 0;
+    for (GeneratedKeyPair kp : generatedKeyPairs) {
+      i++;
+      if (kp.getConfigKeyPair() instanceof AzureVaultKeyPair) {
+        AzureVaultKeyPair akp = (AzureVaultKeyPair) kp.getConfigKeyPair();
+        String type = "azure";
+        String pubKey = kp.getPublicKey();
+        String pubId = akp.getPublicKeyId();
+        String privId = akp.getPrivateKeyId();
+        String pubVersion = akp.getPublicKeyVersion();
+        String privVersion = akp.getPrivateKeyVersion();
+
+        sj.add(String.format("\t%d: type=%s, pub=%s", i, type, pubKey));
+        sj.add(String.format("\t\tpub: id=%s, version=%s", pubId, pubVersion));
+        sj.add(String.format("\t\tprv: id=%s, version=%s", privId, privVersion));
+      } else if (kp.getConfigKeyPair() instanceof AWSKeyPair) {
+        AWSKeyPair akp = (AWSKeyPair) kp.getConfigKeyPair();
+        String type = "aws";
+        String pubKey = kp.getPublicKey();
+        String pubId = akp.getPublicKeyId();
+        String privId = akp.getPrivateKeyId();
+
+        sj.add(String.format("\t%d: type=%s, pub=%s", i, type, pubKey));
+        sj.add(String.format("\t\tpub: id=%s", pubId));
+        sj.add(String.format("\t\tprv: id=%s", privId));
+      } else if (kp.getConfigKeyPair() instanceof HashicorpVaultKeyPair) {
+        HashicorpVaultKeyPair hkp = (HashicorpVaultKeyPair) kp.getConfigKeyPair();
+        String type = "hashicorp";
+        String pubKey = kp.getPublicKey();
+        String name = hkp.getSecretName();
+        String secretEngine = hkp.getSecretEngineName();
+        String version = hkp.getSecretVersion().toString();
+        String pubId = hkp.getPublicKeyId();
+        String privId = hkp.getPrivateKeyId();
+
+        sj.add(String.format("\t%d: type=%s, pub=%s", i, type, pubKey));
+        sj.add(
+            String.format(
+                "\t\tpub: name=%s/%s, id=%s, version=%s", secretEngine, name, pubId, version));
+        sj.add(
+            String.format(
+                "\t\tprv: name=%s/%s, id=%s, version=%s", secretEngine, name, privId, version));
+      } else if (kp.getConfigKeyPair() instanceof FilesystemKeyPair) {
+        FilesystemKeyPair fkp = (FilesystemKeyPair) kp.getConfigKeyPair();
+        String type = "file";
+        String pubPath = fkp.getPublicKeyPath().toAbsolutePath().toString();
+        String privPath = fkp.getPrivateKeyPath().toAbsolutePath().toString();
+        String pubKey = kp.getPublicKey();
+
+        sj.add(String.format("\t%d: type=%s, pub=%s", i, type, pubKey));
+        sj.add(String.format("\t\tpub: path=%s", pubPath));
+        sj.add(String.format("\t\tprv: path=%s", privPath));
+      } else {
+        sj.add(
+            String.format("\t%d: type=unknown, pub=%s", i, kp.getConfigKeyPair().getPublicKey()));
+      }
+    }
+    System.out.println(sj);
+  }
+
+  static void prepareConfigForNewKeys(Config config) {
+    if (Objects.isNull(config.getKeys())) {
+      config.setKeys(new KeyConfiguration());
+    }
+    if (Objects.isNull(config.getKeys().getKeyData())) {
+      config.getKeys().setKeyData(new ArrayList<>());
+    }
+  }
+
   @Override
   public CliResult call() throws IOException {
     if (Objects.nonNull(fileUpdateOptions) && Objects.isNull(fileUpdateOptions.getConfig())) {
@@ -118,12 +196,10 @@ public class KeyGenCommand implements Callable<CliResult> {
               .flatMap(c -> c.getKeyVaultConfig(keyVaultConfigOptions.getVaultType()))
               .orElse(null);
     } else {
-
       final KeyVaultHandler keyVaultHandler = new DispatchingKeyVaultHandler();
       keyVaultConfig = keyVaultHandler.handle(keyVaultConfigOptions);
 
       if (keyVaultConfig.getKeyVaultType() == KeyVaultType.HASHICORP) {
-
         if (Objects.isNull(keyOut)) {
           throw new CliException(
               "At least one -filename must be provided when saving generated keys in a Hashicorp Vault");
@@ -145,23 +221,29 @@ public class KeyGenCommand implements Callable<CliResult> {
             .map(List::copyOf)
             .orElseGet(() -> List.of(""));
 
-    final List<ConfigKeyPair> newConfigKeyPairs =
+    final List<GeneratedKeyPair> generatedKeyPairs =
         newKeyNames.stream()
             .map(name -> keyGenerator.generate(name, argonOptions, keyVaultOptions))
             .collect(Collectors.toList());
 
+    output(generatedKeyPairs);
+
     final List<char[]> newPasswords =
-        newConfigKeyPairs.stream()
+        generatedKeyPairs.stream()
             .filter(Objects::nonNull)
+            .map(GeneratedKeyPair::getConfigKeyPair)
             .map(ConfigKeyPair::getPassword)
             .collect(Collectors.toList());
-
-    final List<KeyData> newKeyData =
-        newConfigKeyPairs.stream().map(keyDataMarshaller::marshal).collect(Collectors.toList());
 
     if (Objects.isNull(fileUpdateOptions)) {
       return new CliResult(0, true, null);
     }
+
+    final List<KeyData> newKeyData =
+        generatedKeyPairs.stream()
+            .map(GeneratedKeyPair::getConfigKeyPair)
+            .map(keyDataMarshaller::marshal)
+            .collect(Collectors.toList());
 
     // prepare config for addition of new keys if required
     prepareConfigForNewKeys(fileUpdateOptions.getConfig());
@@ -183,14 +265,5 @@ public class KeyGenCommand implements Callable<CliResult> {
     }
 
     return new CliResult(0, true, fileUpdateOptions.getConfig());
-  }
-
-  static void prepareConfigForNewKeys(Config config) {
-    if (Objects.isNull(config.getKeys())) {
-      config.setKeys(new KeyConfiguration());
-    }
-    if (Objects.isNull(config.getKeys().getKeyData())) {
-      config.getKeys().setKeyData(new ArrayList<>());
-    }
   }
 }

--- a/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/PicoCliDelegateTest.java
+++ b/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/PicoCliDelegateTest.java
@@ -10,10 +10,11 @@ import com.quorum.tessera.cli.CliResult;
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.KeyDataConfig;
 import com.quorum.tessera.config.Peer;
-import com.quorum.tessera.config.keypairs.DirectKeyPair;
+import com.quorum.tessera.config.keypairs.ConfigKeyPair;
 import com.quorum.tessera.config.keypairs.FilesystemKeyPair;
 import com.quorum.tessera.config.keys.KeyEncryptor;
 import com.quorum.tessera.config.util.JaxbUtil;
+import com.quorum.tessera.key.generation.GeneratedKeyPair;
 import com.quorum.tessera.key.generation.KeyGenerator;
 import com.quorum.tessera.key.generation.KeyGeneratorFactory;
 import jakarta.validation.ConstraintViolationException;
@@ -269,8 +270,12 @@ public class PicoCliDelegateTest {
   @Test
   public void keygen() throws Exception {
 
-    FilesystemKeyPair keypair = mock(FilesystemKeyPair.class);
-    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(keypair);
+    ConfigKeyPair ckp = mock(ConfigKeyPair.class);
+    when(ckp.getPublicKey()).thenReturn("mypub");
+    GeneratedKeyPair gkp = mock(GeneratedKeyPair.class);
+    when(gkp.getConfigKeyPair()).thenReturn(ckp);
+
+    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(gkp);
 
     CliResult result = cliDelegate.execute("-keygen", "-filename", UUID.randomUUID().toString());
 
@@ -284,8 +289,12 @@ public class PicoCliDelegateTest {
 
   @Test
   public void keygenThenExit() throws Exception {
-    FilesystemKeyPair keypair = mock(FilesystemKeyPair.class);
-    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(keypair);
+    ConfigKeyPair ckp = mock(ConfigKeyPair.class);
+    when(ckp.getPublicKey()).thenReturn("mypub");
+    GeneratedKeyPair gkp = mock(GeneratedKeyPair.class);
+    when(gkp.getConfigKeyPair()).thenReturn(ckp);
+
+    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(gkp);
 
     final CliResult result = cliDelegate.execute("-keygen", "--encryptor.type", "NACL");
 
@@ -315,7 +324,8 @@ public class PicoCliDelegateTest {
     KeyEncryptor keyEncryptor = mock(KeyEncryptor.class);
 
     FilesystemKeyPair keypair = new FilesystemKeyPair(publicKeyPath, privateKeyPath, keyEncryptor);
-    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(keypair);
+    GeneratedKeyPair gkp = new GeneratedKeyPair(keypair, "SOMEDATA");
+    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(gkp);
 
     Path unixSocketPath = Files.createTempFile(UUID.randomUUID().toString(), ".ipc");
     Map<String, Object> params = new HashMap<>();
@@ -376,7 +386,8 @@ public class PicoCliDelegateTest {
     KeyEncryptor keyEncryptor = mock(KeyEncryptor.class);
 
     FilesystemKeyPair keypair = new FilesystemKeyPair(publicKeyPath, privateKeyPath, keyEncryptor);
-    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(keypair);
+    GeneratedKeyPair gkp = new GeneratedKeyPair(keypair, "SOMEDATA");
+    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(gkp);
 
     Path unixSocketPath = Files.createTempFile(UUID.randomUUID().toString(), ".ipc");
     Map<String, Object> params = new HashMap<>();
@@ -444,7 +455,8 @@ public class PicoCliDelegateTest {
     KeyEncryptor keyEncryptor = mock(KeyEncryptor.class);
 
     FilesystemKeyPair keypair = new FilesystemKeyPair(publicKeyPath, privateKeyPath, keyEncryptor);
-    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(keypair);
+    GeneratedKeyPair gkp = new GeneratedKeyPair(keypair, "SOMEDATA");
+    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(gkp);
 
     Path unixSocketPath = Files.createTempFile(UUID.randomUUID().toString(), ".ipc");
     Map<String, Object> params = new HashMap<>();
@@ -726,8 +738,12 @@ public class PicoCliDelegateTest {
   @Test
   public void suppressStartupForKeygenOption() throws Exception {
 
-    when(keyGenerator.generate(anyString(), eq(null), eq(null)))
-        .thenReturn(mock(DirectKeyPair.class));
+    ConfigKeyPair ckp = mock(ConfigKeyPair.class);
+    when(ckp.getPublicKey()).thenReturn("mypub");
+    GeneratedKeyPair gkp = mock(GeneratedKeyPair.class);
+    when(gkp.getConfigKeyPair()).thenReturn(ckp);
+
+    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(gkp);
 
     final CliResult cliResult = cliDelegate.execute("-keygen", "--encryptor.type", "NACL");
 
@@ -746,7 +762,8 @@ public class PicoCliDelegateTest {
     Files.write(publicKeyPath, Arrays.asList("SOMEDATA"));
 
     FilesystemKeyPair keypair = new FilesystemKeyPair(publicKeyPath, privateKeyPath, null);
-    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(keypair);
+    GeneratedKeyPair gkp = new GeneratedKeyPair(keypair, "SOMEDATA");
+    when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(gkp);
 
     final Path configFile = Paths.get(getClass().getResource("/sample-config.json").toURI());
 

--- a/cvss-suppressions.xml
+++ b/cvss-suppressions.xml
@@ -1,20 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-        <suppress>
-            <notes><![CDATA[
+    <suppress>
+        <notes><![CDATA[
         file name: partyinfo-model.jar (project :tessera-jaxrs:partyinfo-model).
-   Suppress CVE-2020-36460, a vulnerability with the Rust crate 'model' that incorrectly triggers due to a combination of the 'partyinfo-model' module's name and the current development version '22.1.2-SNAPSHOT'.
-   This should be able to be removed once we progress past 22.1.2.
+   Suppress CVE-2020-36460, a vulnerability with the Rust crate 'model' that incorrectly triggers due to the naming of the 'partyinfo-model' module.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/net\.consensys\.quorum\.tessera/partyinfo\-model@.*$</packageUrl>
         <cpe>cpe:/a:model_project:model</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: partyinfo-model.jar (project :tessera-jaxrs:partyinfo-model)
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/net\.consensys\.quorum\.tessera/partyinfo\-model@.*$</packageUrl>
-        <cve>CVE-2020-36460</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -23,5 +15,13 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
         <cve>CVE-2018-14335</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar, and other spring jars
+   Not applicable to how Spring libraries are used within hashicorp-key-vault module
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
     </suppress>
 </suppressions>

--- a/key-generation/src/main/java/com/quorum/tessera/key/generation/AzureVaultKeyGenerator.java
+++ b/key-generation/src/main/java/com/quorum/tessera/key/generation/AzureVaultKeyGenerator.java
@@ -6,6 +6,7 @@ import com.quorum.tessera.encryption.Encryptor;
 import com.quorum.tessera.encryption.Key;
 import com.quorum.tessera.encryption.KeyPair;
 import com.quorum.tessera.key.vault.KeyVaultService;
+import com.quorum.tessera.key.vault.SetSecretResponse;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -27,7 +28,7 @@ public class AzureVaultKeyGenerator implements KeyGenerator {
   }
 
   @Override
-  public AzureVaultKeyPair generate(
+  public GeneratedKeyPair generate(
       String filename, ArgonOptions encryptionOptions, KeyVaultOptions keyVaultOptions) {
     final KeyPair keys = this.nacl.generateNewKeys();
 
@@ -50,15 +51,23 @@ public class AzureVaultKeyGenerator implements KeyGenerator {
     publicId.append("Pub");
     privateId.append("Key");
 
-    saveKeyInVault(publicId.toString(), keys.getPublicKey());
-    saveKeyInVault(privateId.toString(), keys.getPrivateKey());
+    SetSecretResponse pubResp = saveKeyInVault(publicId.toString(), keys.getPublicKey());
+    SetSecretResponse privResp = saveKeyInVault(privateId.toString(), keys.getPrivateKey());
 
-    return new AzureVaultKeyPair(publicId.toString(), privateId.toString(), null, null);
+    AzureVaultKeyPair keyPair =
+        new AzureVaultKeyPair(
+            publicId.toString(),
+            privateId.toString(),
+            pubResp.getProperty("version"),
+            privResp.getProperty("version"));
+
+    return new GeneratedKeyPair(keyPair, keys.getPublicKey().encodeToBase64());
   }
 
-  private void saveKeyInVault(String id, Key key) {
-    keyVaultService.setSecret(Map.of("secretName", id, "secret", key.encodeToBase64()));
+  private SetSecretResponse saveKeyInVault(String id, Key key) {
+    SetSecretResponse resp =
+        keyVaultService.setSecret(Map.of("secretName", id, "secret", key.encodeToBase64()));
     LOGGER.debug("Key {} saved to vault with id {}", key.encodeToBase64(), id);
-    LOGGER.info("Key saved to vault with id {}", id);
+    return resp;
   }
 }

--- a/key-generation/src/main/java/com/quorum/tessera/key/generation/FileKeyGenerator.java
+++ b/key-generation/src/main/java/com/quorum/tessera/key/generation/FileKeyGenerator.java
@@ -46,7 +46,7 @@ public class FileKeyGenerator implements KeyGenerator {
   }
 
   @Override
-  public FilesystemKeyPair generate(
+  public GeneratedKeyPair generate(
       final String filename,
       final ArgonOptions encryptionOptions,
       final KeyVaultOptions keyVaultOptions) {
@@ -108,14 +108,14 @@ public class FileKeyGenerator implements KeyGenerator {
     IOCallback.execute(
         () -> Files.write(privateKeyPath, privateKeyJson.getBytes(UTF_8), CREATE_NEW));
 
-    LOGGER.info("Saved public key to {}", publicKeyPath.toAbsolutePath().toString());
-    LOGGER.info("Saved private key to {}", privateKeyPath.toAbsolutePath().toString());
+    LOGGER.debug("Saved public key to {}", publicKeyPath.toAbsolutePath());
+    LOGGER.debug("Saved private key to {}", privateKeyPath.toAbsolutePath());
 
     final FilesystemKeyPair keyPair =
         new FilesystemKeyPair(publicKeyPath, privateKeyPath, keyEncryptor);
 
     keyPair.withPassword(password);
 
-    return keyPair;
+    return new GeneratedKeyPair(keyPair, publicKeyBase64);
   }
 }

--- a/key-generation/src/main/java/com/quorum/tessera/key/generation/GeneratedKeyPair.java
+++ b/key-generation/src/main/java/com/quorum/tessera/key/generation/GeneratedKeyPair.java
@@ -1,0 +1,23 @@
+package com.quorum.tessera.key.generation;
+
+import com.quorum.tessera.config.keypairs.*;
+
+public class GeneratedKeyPair {
+  // key pair data that can be marshalled and used to update the configfile
+  private ConfigKeyPair configKeyPair;
+
+  private String publicKey;
+
+  public GeneratedKeyPair(ConfigKeyPair configKeyPair, String publicKey) {
+    this.configKeyPair = configKeyPair;
+    this.publicKey = publicKey;
+  }
+
+  public ConfigKeyPair getConfigKeyPair() {
+    return configKeyPair;
+  }
+
+  public String getPublicKey() {
+    return publicKey;
+  }
+}

--- a/key-generation/src/main/java/com/quorum/tessera/key/generation/KeyGenerator.java
+++ b/key-generation/src/main/java/com/quorum/tessera/key/generation/KeyGenerator.java
@@ -1,10 +1,9 @@
 package com.quorum.tessera.key.generation;
 
 import com.quorum.tessera.config.ArgonOptions;
-import com.quorum.tessera.config.keypairs.ConfigKeyPair;
 
 public interface KeyGenerator {
 
-  ConfigKeyPair generate(
+  GeneratedKeyPair generate(
       String filename, ArgonOptions encryptionOptions, KeyVaultOptions keyVaultOptions);
 }

--- a/key-generation/src/test/java/com/quorum/tessera/key/generation/AWSSecretManagerKeyGeneratorTest.java
+++ b/key-generation/src/test/java/com/quorum/tessera/key/generation/AWSSecretManagerKeyGeneratorTest.java
@@ -46,7 +46,7 @@ public class AWSSecretManagerKeyGeneratorTest {
     final String pubVaultId = vaultId + "Pub";
     final String privVaultId = vaultId + "Key";
 
-    final AWSKeyPair result = awsSecretManagerKeyGenerator.generate(vaultId, null, null);
+    final GeneratedKeyPair result = awsSecretManagerKeyGenerator.generate(vaultId, null, null);
 
     final ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
 
@@ -66,10 +66,11 @@ public class AWSSecretManagerKeyGeneratorTest {
 
     verifyNoMoreInteractions(keyVaultService);
 
-    final AWSKeyPair expected = new AWSKeyPair(pubVaultId, privVaultId);
+    final AWSKeyPair kp = new AWSKeyPair(pubVaultId, privVaultId);
+    final GeneratedKeyPair expected = new GeneratedKeyPair(kp, pub.encodeToBase64());
 
-    assertThat(result).isExactlyInstanceOf(AWSKeyPair.class);
-    assertThat(result).isEqualToComparingFieldByField(expected);
+    assertThat(result).isExactlyInstanceOf(GeneratedKeyPair.class);
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
   }
 
   @Test

--- a/key-generation/src/test/java/com/quorum/tessera/key/generation/AzureVaultKeyGeneratorTest.java
+++ b/key-generation/src/test/java/com/quorum/tessera/key/generation/AzureVaultKeyGeneratorTest.java
@@ -11,6 +11,7 @@ import com.quorum.tessera.encryption.KeyPair;
 import com.quorum.tessera.encryption.PrivateKey;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.key.vault.KeyVaultService;
+import com.quorum.tessera.key.vault.SetSecretResponse;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,8 @@ public class AzureVaultKeyGeneratorTest {
   private final String privStr = "private";
   private final PublicKey pub = PublicKey.from(pubStr.getBytes());
   private final PrivateKey priv = PrivateKey.from(privStr.getBytes());
+  private final String pubVersion = "pubVersion";
+  private final String privVersion = "privVersion";
 
   private Encryptor encryptor;
   private KeyVaultService keyVaultService;
@@ -35,8 +38,11 @@ public class AzureVaultKeyGeneratorTest {
     this.keyVaultService = mock(KeyVaultService.class);
 
     final KeyPair keyPair = new KeyPair(pub, priv);
-
     when(encryptor.generateNewKeys()).thenReturn(keyPair);
+
+    final SetSecretResponse setRespPub = new SetSecretResponse(Map.of("version", pubVersion));
+    final SetSecretResponse setRespPriv = new SetSecretResponse(Map.of("version", privVersion));
+    when(keyVaultService.setSecret(anyMap())).thenReturn(setRespPub, setRespPriv);
 
     azureVaultKeyGenerator = new AzureVaultKeyGenerator(encryptor, keyVaultService);
   }
@@ -47,7 +53,7 @@ public class AzureVaultKeyGeneratorTest {
     final String pubVaultId = vaultId + "Pub";
     final String privVaultId = vaultId + "Key";
 
-    final AzureVaultKeyPair result = azureVaultKeyGenerator.generate(vaultId, null, null);
+    final GeneratedKeyPair result = azureVaultKeyGenerator.generate(vaultId, null, null);
 
     final ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
 
@@ -68,9 +74,11 @@ public class AzureVaultKeyGeneratorTest {
 
     verifyNoMoreInteractions(keyVaultService);
 
-    final AzureVaultKeyPair expected = new AzureVaultKeyPair(pubVaultId, privVaultId, null, null);
+    final AzureVaultKeyPair kp =
+        new AzureVaultKeyPair(pubVaultId, privVaultId, pubVersion, privVersion);
+    final GeneratedKeyPair expected = new GeneratedKeyPair(kp, pub.encodeToBase64());
 
-    assertThat(result).isEqualToComparingFieldByFieldRecursively(expected);
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
   }
 
   @Test

--- a/key-generation/src/test/java/com/quorum/tessera/key/generation/FileKeyGeneratorTest.java
+++ b/key-generation/src/test/java/com/quorum/tessera/key/generation/FileKeyGeneratorTest.java
@@ -67,18 +67,20 @@ public class FileKeyGeneratorTest {
 
   @Test
   public void generateFromKeyDataUnlockedPrivateKey() throws IOException {
-
     doReturn(keyPair).when(encryptor).generateNewKeys();
 
     String filename = UUID.randomUUID().toString();
     final Path tmpDir = Files.createTempDirectory("keygen").toAbsolutePath().resolve(filename);
 
-    final FilesystemKeyPair generated = generator.generate(tmpDir.toString(), null, null);
+    final GeneratedKeyPair generated = generator.generate(tmpDir.toString(), null, null);
 
-    assertThat(generated).isInstanceOf(FilesystemKeyPair.class);
     assertThat(generated.getPublicKey()).isEqualTo("cHVibGljS2V5");
-    assertThat(generated.getPrivateKey()).isEqualTo("cHJpdmF0ZUtleQ==");
-    assertThat(generated.getInlineKeypair().getPrivateKeyConfig().getType()).isEqualTo(UNLOCKED);
+    assertThat(generated.getConfigKeyPair()).isInstanceOf(FilesystemKeyPair.class);
+    assertThat(generated.getConfigKeyPair().getPublicKey()).isEqualTo("cHVibGljS2V5");
+    assertThat(generated.getConfigKeyPair().getPrivateKey()).isEqualTo("cHJpdmF0ZUtleQ==");
+
+    FilesystemKeyPair fkp = (FilesystemKeyPair) generated.getConfigKeyPair();
+    assertThat(fkp.getInlineKeypair().getPrivateKeyConfig().getType()).isEqualTo(UNLOCKED);
 
     verify(encryptor).generateNewKeys();
   }
@@ -109,10 +111,14 @@ public class FileKeyGeneratorTest {
         .when(keyEncryptor)
         .encryptPrivateKey(any(PrivateKey.class), any(), eq(null));
 
-    final FilesystemKeyPair generated = generator.generate(keyFilesName, null, null);
+    final GeneratedKeyPair generated = generator.generate(keyFilesName, null, null);
 
-    final KeyDataConfig pkd = generated.getInlineKeypair().getPrivateKeyConfig();
     assertThat(generated.getPublicKey()).isEqualTo("cHVibGljS2V5");
+    assertThat(generated.getConfigKeyPair()).isInstanceOf(FilesystemKeyPair.class);
+    assertThat(generated.getConfigKeyPair().getPublicKey()).isEqualTo("cHVibGljS2V5");
+
+    final FilesystemKeyPair fkp = (FilesystemKeyPair) generated.getConfigKeyPair();
+    final KeyDataConfig pkd = fkp.getInlineKeypair().getPrivateKeyConfig();
     assertThat(pkd.getSbox()).isEqualTo("sbox");
     assertThat(pkd.getSnonce()).isEqualTo("snonce");
     assertThat(pkd.getAsalt()).isEqualTo("salt");
@@ -129,7 +135,7 @@ public class FileKeyGeneratorTest {
 
     doReturn(keyPair).when(encryptor).generateNewKeys();
 
-    final FilesystemKeyPair generated = generator.generate(keyFilesName, null, null);
+    final GeneratedKeyPair generated = generator.generate(keyFilesName, null, null);
 
     assertThat(Files.exists(tempFolder.resolve("providingPathSavesToFile.pub"))).isTrue();
     assertThat(Files.exists(tempFolder.resolve("providingPathSavesToFile.key"))).isTrue();
@@ -144,7 +150,7 @@ public class FileKeyGeneratorTest {
 
     doReturn(keyPair).when(encryptor).generateNewKeys();
 
-    final FilesystemKeyPair generated = generator.generate("", null, null);
+    final GeneratedKeyPair generated = generator.generate("", null, null);
 
     assertThat(Files.exists(Paths.get(".pub"))).isTrue();
     assertThat(Files.exists(Paths.get(".key"))).isTrue();

--- a/key-generation/src/test/java/com/quorum/tessera/key/generation/HashicorpVaultKeyGeneratorTest.java
+++ b/key-generation/src/test/java/com/quorum/tessera/key/generation/HashicorpVaultKeyGeneratorTest.java
@@ -9,6 +9,7 @@ import com.quorum.tessera.encryption.KeyPair;
 import com.quorum.tessera.encryption.PrivateKey;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.key.vault.KeyVaultService;
+import com.quorum.tessera.key.vault.SetSecretResponse;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -65,15 +66,18 @@ public class HashicorpVaultKeyGeneratorTest {
     String secretEngine = "secretEngine";
     String filename = "secretName";
 
+    final SetSecretResponse setResp = new SetSecretResponse(Map.of("version", "1"));
+    when(keyVaultService.setSecret(anyMap())).thenReturn(setResp);
+
     KeyVaultOptions keyVaultOptions = mock(KeyVaultOptions.class);
     when(keyVaultOptions.getSecretEngineName()).thenReturn(secretEngine);
 
-    HashicorpVaultKeyPair result =
-        hashicorpVaultKeyGenerator.generate(filename, null, keyVaultOptions);
+    GeneratedKeyPair result = hashicorpVaultKeyGenerator.generate(filename, null, keyVaultOptions);
 
-    HashicorpVaultKeyPair expected =
-        new HashicorpVaultKeyPair("publicKey", "privateKey", secretEngine, filename, null);
-    assertThat(result).isEqualToComparingFieldByField(expected);
+    HashicorpVaultKeyPair kp =
+        new HashicorpVaultKeyPair("publicKey", "privateKey", secretEngine, filename, 1);
+    GeneratedKeyPair expected = new GeneratedKeyPair(kp, pub.encodeToBase64());
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
 
     final ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
     verify(keyVaultService).setSecret(captor.capture());

--- a/key-vault/aws-key-vault/build.gradle
+++ b/key-vault/aws-key-vault/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id "application"
 }
 
-def nettyVersion = "4.1.46.Final"
+//def nettyVersion = "4.1.76.Final"
 
 dependencyCheck {
   failBuildOnCVSS = 11
@@ -21,26 +21,21 @@ configurations.all {
 
 dependencies {
   implementation project(":config")
-
-  implementation("software.amazon.awssdk:secretsmanager:2.10.25")
-
-  implementation("software.amazon.awssdk:apache-client:2.10.25")
-
-
-  implementation("org.apache.httpcomponents:httpclient:4.5.9")
-
   implementation project(":key-vault:key-vault-api")
 
-  //   compile "io.netty:netty:"+ nettyVersion
-  implementation "io.netty:netty-handler:$nettyVersion"
-  implementation "io.netty:netty-common:$nettyVersion"
-  implementation "io.netty:netty-buffer:$nettyVersion"
-  implementation "io.netty:netty-transport:$nettyVersion"
-  implementation "io.netty:netty-codec:$nettyVersion"
-  implementation "io.netty:netty-codec-http:$nettyVersion"
-  implementation "io.netty:netty-codec-http2:$nettyVersion"
-  implementation "io.netty:netty-transport-native-unix-common:$nettyVersion"
-  implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+  implementation("software.amazon.awssdk:secretsmanager:2.17.204")
+  implementation("software.amazon.awssdk:apache-client:2.17.204")
+
+  //  the aws dependencies often introduce CVE vulnerabilities - keep this code block here as a guide for if netty causes problems and an aws patch isn't available
+  //  implementation "io.netty:netty-handler:$nettyVersion"
+  //  implementation "io.netty:netty-common:$nettyVersion"
+  //  implementation "io.netty:netty-buffer:$nettyVersion"
+  //  implementation "io.netty:netty-transport:$nettyVersion"
+  //  implementation "io.netty:netty-codec:$nettyVersion"
+  //  implementation "io.netty:netty-codec-http:$nettyVersion"
+  //  implementation "io.netty:netty-codec-http2:$nettyVersion"
+  //  implementation "io.netty:netty-transport-native-unix-common:$nettyVersion"
+  //  implementation "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
 
   implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
   implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"

--- a/key-vault/aws-key-vault/src/main/java/com/quorum/tessera/key/vault/aws/AWSKeyVaultService.java
+++ b/key-vault/aws-key-vault/src/main/java/com/quorum/tessera/key/vault/aws/AWSKeyVaultService.java
@@ -1,16 +1,12 @@
 package com.quorum.tessera.key.vault.aws;
 
 import com.quorum.tessera.key.vault.KeyVaultService;
+import com.quorum.tessera.key.vault.SetSecretResponse;
 import com.quorum.tessera.key.vault.VaultSecretNotFoundException;
 import java.util.Map;
 import java.util.Objects;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
-import software.amazon.awssdk.services.secretsmanager.model.InvalidParameterException;
-import software.amazon.awssdk.services.secretsmanager.model.InvalidRequestException;
-import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.secretsmanager.model.*;
 
 public class AWSKeyVaultService implements KeyVaultService {
 
@@ -26,7 +22,6 @@ public class AWSKeyVaultService implements KeyVaultService {
 
   @Override
   public String getSecret(Map<String, String> getSecretData) {
-
     final String secretName = getSecretData.get(SECRET_NAME_KEY);
 
     GetSecretValueRequest getSecretValueRequest =
@@ -51,14 +46,15 @@ public class AWSKeyVaultService implements KeyVaultService {
   }
 
   @Override
-  public Object setSecret(Map<String, String> setSecretData) {
-
+  public SetSecretResponse setSecret(Map<String, String> setSecretData) {
     final String secretName = setSecretData.get(SECRET_NAME_KEY);
     final String secret = setSecretData.get(SECRET_KEY);
 
     CreateSecretRequest createSecretRequest =
         CreateSecretRequest.builder().name(secretName).secretString(secret).build();
 
-    return secretsManager.createSecret(createSecretRequest);
+    CreateSecretResponse r = secretsManager.createSecret(createSecretRequest);
+
+    return new SetSecretResponse(Map.of("version", r.versionId()));
   }
 }

--- a/key-vault/aws-key-vault/src/test/java/com/quorum/tessera/key/vault/aws/AWSKeyVaultServiceTest.java
+++ b/key-vault/aws-key-vault/src/test/java/com/quorum/tessera/key/vault/aws/AWSKeyVaultServiceTest.java
@@ -12,11 +12,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
-import software.amazon.awssdk.services.secretsmanager.model.InvalidParameterException;
-import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.secretsmanager.model.*;
 
 public class AWSKeyVaultServiceTest {
 
@@ -108,6 +104,10 @@ public class AWSKeyVaultServiceTest {
 
     String secretName = "id";
     String secret = "secret";
+
+    CreateSecretResponse resp = mock(CreateSecretResponse.class);
+    when(secretsManager.createSecret(any(CreateSecretRequest.class))).thenReturn(resp);
+    when(resp.versionId()).thenReturn("vers");
 
     Map<String, String> setSecretData =
         Map.of(

--- a/key-vault/azure-key-vault/build.gradle
+++ b/key-vault/azure-key-vault/build.gradle
@@ -17,8 +17,6 @@ configurations.all {
   exclude group: "jakarta.json"
 }
 
-//def nettyVersion = "4.1.76.Final"
-
 dependencies {
   implementation project(":config")
   implementation project(":key-vault:key-vault-api")

--- a/key-vault/azure-key-vault/build.gradle
+++ b/key-vault/azure-key-vault/build.gradle
@@ -17,22 +17,23 @@ configurations.all {
   exclude group: "jakarta.json"
 }
 
+//def nettyVersion = "4.1.76.Final"
+
 dependencies {
-  implementation platform('io.projectreactor:reactor-bom:2020.0.10')
-
-  // define dependencies without versions
-  implementation 'io.projectreactor.netty:reactor-netty'
-  implementation 'io.projectreactor.netty:reactor-netty-core'
-  implementation 'io.projectreactor.netty:reactor-netty-http'
-
   implementation project(":config")
   implementation project(":key-vault:key-vault-api")
-  implementation "jakarta.annotation:jakarta.annotation-api"
-  implementation "com.sun.activation:jakarta.activation"
 
-  implementation ("com.azure:azure-security-keyvault-secrets:4.2.3")
-  implementation("com.azure:azure-identity:1.3.5")
-  implementation("com.azure:azure-core:1.19.0")
+  implementation ("com.azure:azure-security-keyvault-secrets:4.4.2") {
+    exclude group: 'com.azure', module: 'azure-core-http-netty'
+  }
+  implementation("com.azure:azure-identity:1.5.1") {
+    exclude group: 'com.azure', module: 'azure-core-http-netty'
+  }
+  implementation("com.azure:azure-core:1.29.1") {
+    exclude group: 'com.azure', module: 'azure-core-http-netty'
+  }
+  implementation 'com.azure:azure-core-http-okhttp:1.10.1'
+  implementation 'com.squareup.okio:okio:3.1.0'
 
   testImplementation "org.glassfish:jakarta.json"
 

--- a/key-vault/azure-key-vault/src/main/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultService.java
+++ b/key-vault/azure-key-vault/src/main/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultService.java
@@ -4,6 +4,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import com.quorum.tessera.key.vault.KeyVaultService;
+import com.quorum.tessera.key.vault.SetSecretResponse;
 import com.quorum.tessera.key.vault.VaultSecretNotFoundException;
 import java.util.Map;
 import java.util.Objects;
@@ -48,11 +49,15 @@ public class AzureKeyVaultService implements KeyVaultService {
   }
 
   @Override
-  public Object setSecret(Map<String, String> azureSetSecretData) {
+  public SetSecretResponse setSecret(Map<String, String> azureSetSecretData) {
 
     final String secretName = azureSetSecretData.get(SECRET_NAME_KEY);
     final String secret = azureSetSecretData.get(SECRET_KEY);
 
-    return secretClient.setSecret(secretName, secret);
+    KeyVaultSecret kvs = secretClient.setSecret(secretName, secret);
+
+    SetSecretResponse resp =
+        new SetSecretResponse(Map.of("version", kvs.getProperties().getVersion()));
+    return resp;
   }
 }

--- a/key-vault/azure-key-vault/src/main/java/module-info.java
+++ b/key-vault/azure-key-vault/src/main/java/module-info.java
@@ -3,13 +3,17 @@ module tessera.keyvault.azure {
   requires org.slf4j;
   requires tessera.config;
   requires tessera.keyvault.api;
-  requires jakarta.annotation;
+  //    requires jakarta.annotation;
   requires com.azure.identity;
   requires com.azure.security.keyvault.secrets;
-  requires com.azure.http.netty;
-  requires reactor.netty;
-  requires io.netty.handler;
-  requires io.netty.common;
+  //  requires com.azure.http.okhttp;
+  //  requires com.azure.http.netty;
+  //  requires reactor.netty;
+  //  requires io.netty.handler;
+  //  requires io.netty.common;
+  //  requires okio;
+
+  requires kotlin.stdlib;
 
   provides com.quorum.tessera.key.vault.KeyVaultServiceFactory with
       com.quorum.tessera.key.vault.azure.AzureKeyVaultServiceFactory;

--- a/key-vault/azure-key-vault/src/main/java/module-info.java
+++ b/key-vault/azure-key-vault/src/main/java/module-info.java
@@ -3,16 +3,8 @@ module tessera.keyvault.azure {
   requires org.slf4j;
   requires tessera.config;
   requires tessera.keyvault.api;
-  //    requires jakarta.annotation;
   requires com.azure.identity;
   requires com.azure.security.keyvault.secrets;
-  //  requires com.azure.http.okhttp;
-  //  requires com.azure.http.netty;
-  //  requires reactor.netty;
-  //  requires io.netty.handler;
-  //  requires io.netty.common;
-  //  requires okio;
-
   requires kotlin.stdlib;
 
   provides com.quorum.tessera.key.vault.KeyVaultServiceFactory with

--- a/key-vault/azure-key-vault/src/test/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultServiceTest.java
+++ b/key-vault/azure-key-vault/src/test/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultServiceTest.java
@@ -1,13 +1,14 @@
 package com.quorum.tessera.key.vault.azure;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.HttpResponse;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import com.azure.security.keyvault.secrets.models.SecretProperties;
+import com.quorum.tessera.key.vault.SetSecretResponse;
 import com.quorum.tessera.key.vault.VaultSecretNotFoundException;
 import java.util.Map;
 import org.junit.Before;
@@ -89,10 +90,14 @@ public class AzureKeyVaultServiceTest {
 
     final KeyVaultSecret newSecret = mock(KeyVaultSecret.class);
     when(secretClient.setSecret(secretName, secret)).thenReturn(newSecret);
+    final SecretProperties props = mock(SecretProperties.class);
+    when(newSecret.getProperties()).thenReturn(props);
+    when(props.getVersion()).thenReturn("myvers");
 
-    final Object result = keyVaultService.setSecret(setSecretData);
+    final SetSecretResponse result = keyVaultService.setSecret(setSecretData);
 
-    assertThat(result).isSameAs(newSecret);
+    assertThat(result.getProperties()).size().isEqualTo(1);
+    assertThat(result.getProperties()).contains(entry("version", "myvers"));
     verify(secretClient).setSecret("secret-name", "secret-value");
   }
 }

--- a/key-vault/hashicorp-key-vault/build.gradle
+++ b/key-vault/hashicorp-key-vault/build.gradle
@@ -18,7 +18,7 @@ configurations.all {
   exclude group: "jakarta.json"
 }
 
-def springVersion = "5.3.5"
+def springVersion = "5.3.20"
 dependencies {
   implementation project(":config")
   implementation project(":key-vault:key-vault-api")

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultService.java
@@ -3,6 +3,7 @@ package com.quorum.tessera.key.vault.hashicorp;
 import static java.util.function.Predicate.not;
 
 import com.quorum.tessera.key.vault.KeyVaultService;
+import com.quorum.tessera.key.vault.SetSecretResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,7 +67,7 @@ public class HashicorpKeyVaultService implements KeyVaultService {
   }
 
   @Override
-  public Object setSecret(Map<String, String> hashicorpSetSecretData) {
+  public SetSecretResponse setSecret(Map<String, String> hashicorpSetSecretData) {
 
     String secretName = hashicorpSetSecretData.get(SECRET_NAME_KEY);
     String secretEngineName = hashicorpSetSecretData.get(SECRET_ENGINE_NAME_KEY);
@@ -84,7 +85,9 @@ public class HashicorpKeyVaultService implements KeyVaultService {
         vaultVersionedKeyValueTemplateFactory.createVaultVersionedKeyValueTemplate(
             vaultOperations, secretEngineName);
     try {
-      return keyValueOperations.put(secretName, nameValuePairs);
+      Versioned.Metadata metadata = keyValueOperations.put(secretName, nameValuePairs);
+      return new SetSecretResponse(
+          Map.of("version", String.valueOf(metadata.getVersion().getVersion())));
     } catch (NullPointerException ex) {
       throw new HashicorpVaultException(
           "Unable to save generated secret to vault.  Ensure that the secret engine being used is a v2 kv secret engine");

--- a/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceTest.java
+++ b/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceTest.java
@@ -1,9 +1,9 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.quorum.tessera.key.vault.SetSecretResponse;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
@@ -175,10 +175,15 @@ public class HashicorpKeyVaultServiceTest {
             vaultOperations, "engine"))
         .thenReturn(vaultVersionedKeyValueTemplate);
 
-    Object result = keyVaultService.setSecret(setSecretData);
+    Versioned.Version version = mock(Versioned.Version.class);
+    when(version.getVersion()).thenReturn(22);
 
-    assertThat(result).isInstanceOf(Versioned.Metadata.class);
-    assertThat(result).isEqualTo(metadata);
+    when(metadata.getVersion()).thenReturn(version);
+
+    SetSecretResponse result = keyVaultService.setSecret(setSecretData);
+
+    assertThat(result.getProperties()).size().isEqualTo(1);
+    assertThat(result.getProperties()).contains(entry("version", "22"));
 
     verify(vaultVersionedKeyValueTemplateFactory)
         .createVaultVersionedKeyValueTemplate(vaultOperations, "engine");

--- a/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/KeyVaultService.java
+++ b/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/KeyVaultService.java
@@ -6,5 +6,5 @@ public interface KeyVaultService {
 
   String getSecret(Map<String, String> getSecretData);
 
-  Object setSecret(Map<String, String> setSecretData);
+  SetSecretResponse setSecret(Map<String, String> setSecretData);
 }

--- a/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/SetSecretResponse.java
+++ b/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/SetSecretResponse.java
@@ -1,0 +1,20 @@
+package com.quorum.tessera.key.vault;
+
+import java.util.Map;
+
+public class SetSecretResponse {
+
+  Map<String, String> properties;
+
+  public SetSecretResponse(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public String getProperty(String name) {
+    return properties.get(name);
+  }
+}


### PR DESCRIPTION
* Print keygen results to stdout as current results are buried in log msgs
    * Output includes: generated public key, key-storage specific information (e.g. filepath, vault secret id)
* Update key-vault modules to address non-critical security advisories

Example keygen command and output:

```
$ tessera keygen --keyout /keys/test

1 keypair(s) generated:
	1: type=file, pub=WO5Wj+tXIxf8Amrv6RiOuAqXWGESatnscjal8AmV1AY=
		pub: path=/keys/test.pub
		prv: path=/keys/test.key
```